### PR TITLE
docs: add Markdown README for GitHub presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Pycelium
+
+Minimalist **CLI mycelium simulator** — a fungal head grows toward food on a terminal grid, trails the path, and branches when it feeds.
+
+Part of the [Initial Visuals](https://github.com/initialvisuals) toolkit / game lab. Spiritual cousin to later Mycelium / engine experiments.
+
+### Status
+
+Small learning toy. ASCII animation in the terminal. Windows-oriented clear (`cls`); on other platforms you may want `clear` instead.
+
+### Quick start
+
+```bash
+python pycelium.py
+```
+
+### Legend
+
+| Glyph | Meaning |
+|-------|---------|
+| `●` | Fungal growth head |
+| `◍` | Food source |
+
+### Files
+
+| Path | What |
+|------|------|
+| `pycelium.py` | Simulator |
+| `README.rst` | Original short readme |
+| `LICENSE` | License |
+
+### License
+
+See [LICENSE](LICENSE).
+
+---
+
+**Initial Visuals** — tools, sims, games, and experiments.


### PR DESCRIPTION
## Summary
- Add GitHub-friendly Markdown README (repo previously had only README.rst)
- Document run steps, legend, and Initial Visuals branding

## Test plan
- [ ] Confirm README.md shows as the repo landing doc
