### PR TITLE
HUD English labels beside the 3×5 glyphs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1577,6 +1577,7 @@ dependencies = [
  "clap",
  "env_logger",
  "log",
+ "naga",
  "pollster",
  "rand",
  "rayon",

--- a/README.md
+++ b/README.md
@@ -21,11 +21,23 @@ python pycelium.py
 | `●` | Fungal growth head |
 | `◍` | Food source |
 
+### GPU mesocosm (`pycelium-win`)
+
+Windows / wgpu 3D pedon. Left telemetry HUD keeps the cryptic **3×5 bitmap digits** and fades in short English names (rich density by default; **Tab** cycles rich / sparse / off). Legend: [docs/HUD_LEGEND.md](docs/HUD_LEGEND.md).
+
+```bash
+cargo run -p pycelium-win --release -- --preset demo
+# Tab: label density    hover a meter to focus    --labels sparse|off
+# --bench N is headless and does not open the HUD
+```
+
 ### Files
 
 | Path | What |
 |------|------|
-| `pycelium.py` | Simulator |
+| `pycelium.py` | CLI toy |
+| `pycelium-win/` | GPU mesocosm + telemetry HUD |
+| `docs/HUD_LEGEND.md` | Left HUD map (glyphs + English) |
 | `README.rst` | Original short readme |
 | `LICENSE` | License |
 

--- a/docs/HUD_LEGEND.md
+++ b/docs/HUD_LEGEND.md
@@ -1,0 +1,77 @@
+# Pycelium-win telemetry HUD
+
+Left-column overlay drawn in `pycelium-win/src/shaders/present.wgsl`. The **3×5 bitmap digits stay**; English is a fade-in mono caption next to each meter.
+
+Default density is **rich**: names sit at low opacity, then fade up on hover or after a tip pick. **Tab** cycles `rich → sparse → off → rich`. `--labels sparse|off` sets the startup mode. Bench mode (`--bench`) never opens a window and is unchanged.
+
+## House chrome
+
+- White 5×5 mono captions (not a replacement for the alien 3×5 glyphs)
+- Thin 1-pixel frames around census / fields / slice / tip / param groups
+- Optional elbow ticks on the focused row
+- Tight 2-pixel drop shadow (no blur)
+- Density dial: rich (default), sparse (hover/pick only), off (glyphs only)
+
+## Census (top glyphs)
+
+| Row (UV y) | Glyph | English | Source |
+|------------|-------|---------|--------|
+| 0.06 | 3 digits | `FPS` | present uniform `fps` |
+| 0.12 | 6 digits | `TIPS` | `hud[0]` live apical tips |
+| 0.16 | 5 digits | `FUSIONS` | `hud[1]` anastomosis events |
+| 0.20 | 5 digits | `BRANCHES` | `hud[2]` branch births |
+| 0.24 | 4 digits | `C:N` | `hud[6] / hud[7]` soluble carbon : nitrogen |
+
+`hud[3]` is an internal growth accumulator and is **not** drawn.
+
+## Field bars (teal → brown)
+
+Fill is a strided voxel census (`hud_reduce`, every 4th cell). Color matches the volume look.
+
+| Bar y | English | Color | Buffer / scale |
+|-------|---------|-------|----------------|
+| 0.32 | `HYPHA` | teal `0.55, 0.92, 0.82` | `hud[4]` biomass / 80000 |
+| 0.36 | `CORD` | gold `0.95, 0.72, 0.28` | `hud[5]` internal C / 40000 |
+| 0.40 | `SOL C` | rust `0.78, 0.42, 0.10` | `hud[6]` soluble C / 40000 |
+| 0.44 | `SOL N` | violet `0.55, 0.40, 0.85` | `hud[7]` soluble N / 25000 |
+| 0.48 | `ENZYME` | green `0.32, 0.70, 0.34` | `hud[8]` exoenzyme / 20000 |
+| 0.52 | `ORGANIC` | brown `0.45, 0.32, 0.18` | `hud[9]` uncleaved polymer / 50000 |
+
+## Slice (lower-middle glyphs)
+
+| Row | Glyph | English | Meaning |
+|-----|-------|---------|---------|
+| 0.56 | 4 digits | `SLICE Z` | orthogonal slab depth (voxels) |
+| 0.60 | 3 digits | `THICK` | slab thickness |
+| 0.64 | 3 digits | `ZOOM` | XY field as percent (`zoom * 100`) |
+
+Keys: `[ ]` depth, `; '` thickness, `, .` zoom, arrows pan. Shift = coarse.
+
+## Selected tip
+
+Click in the volume to pick the nearest live tip. `hud[10]` is the pick distance key (not drawn). `hud[11]` is the tip id.
+
+| Row | Glyph | English | Meaning |
+|-----|-------|---------|---------|
+| 0.70 | 6 digits | `TIP` | selected tip slot |
+| 0.74 | 3 digits | `LINEAGE` | inoculum / colony id |
+| 0.78 | 5 digits | `AGE` | tip age |
+| 0.82 | 4 digits | `RESERVE` | internal reserve × 100 |
+
+After a pick, sparse mode keeps this block readable.
+
+## Param knob
+
+| Row | Glyph | English | Meaning |
+|-----|-------|---------|---------|
+| 0.90 | 1 + 4 digits | `PARAM` | slot `1–8` and value × 100 |
+
+Slots: chemotropism, nitrotropism, autotropism, persistence, maintenance, enzyme_k, branch_cost, extension. Keys `1–8` select, `-` / `=` nudge.
+
+## Inset (right)
+
+The orthogonal slab inset is **not** part of the left HUD. It shows hypha + soluble C in the current Z slab, framed, with zoom/pan.
+
+## Controls that do not change presets
+
+`--preset performant|beast|demo`, `--bench`, and host RAM planning are independent of `--labels`. English captions are present-pass only.

--- a/pycelium-win/Cargo.toml
+++ b/pycelium-win/Cargo.toml
@@ -20,3 +20,6 @@ rand = "0.8"
 rayon = "1.10"
 wgpu = "30"
 winit = "0.30"
+
+[dev-dependencies]
+naga = { version = "30.0.1", default-features = false, features = ["wgsl-in"] }

--- a/pycelium-win/src/config.rs
+++ b/pycelium-win/src/config.rs
@@ -250,7 +250,7 @@ mod tests {
         assert_eq!(a.gpu_depth, b.gpu_depth);
         assert_eq!(off.labels, LabelDensity::Off);
         assert_eq!(def.labels, LabelDensity::Rich);
-        assert_eq!(def.preset, Preset::Performant);
+        assert!(matches!(def.preset, Preset::Performant));
     }
 
     #[test]

--- a/pycelium-win/src/config.rs
+++ b/pycelium-win/src/config.rs
@@ -53,6 +53,49 @@ pub struct Args {
 
     #[arg(long)]
     pub bench: Option<u32>,
+
+    /// English HUD label density. Tab cycles rich → sparse → off at runtime.
+    #[arg(long, value_enum, default_value_t = LabelDensity::Rich)]
+    pub labels: LabelDensity,
+}
+
+/// How loudly the left telemetry HUD speaks English.
+/// Cryptic 3×5 glyphs stay visible in every mode.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub enum LabelDensity {
+    /// All meter names at low opacity; hover / pick fades them up.
+    #[default]
+    Rich,
+    /// Names only on hover, pick, or the focused param row.
+    Sparse,
+    /// Glyphs and bars only.
+    Off,
+}
+
+impl LabelDensity {
+    pub fn cycle(self) -> Self {
+        match self {
+            Self::Rich => Self::Sparse,
+            Self::Sparse => Self::Off,
+            Self::Off => Self::Rich,
+        }
+    }
+
+    pub fn as_f32(self) -> f32 {
+        match self {
+            Self::Off => 0.0,
+            Self::Sparse => 1.0,
+            Self::Rich => 2.0,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Rich => "rich",
+            Self::Sparse => "sparse",
+            Self::Off => "off",
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -172,6 +215,7 @@ fn soil_bytes(width: u32, height: u32, layers: u32) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
 
     #[test]
     fn beast_plan_is_large() {
@@ -186,10 +230,52 @@ mod tests {
             vsync: false,
             drift: false,
             bench: None,
+            labels: LabelDensity::Rich,
         };
         let plan = MemoryPlan::from_args(&args);
         assert!(plan.estimated_host_bytes > 1024 * 1024);
         assert!(plan.soil_width >= plan.gpu_width);
         assert!(plan.gpu_depth >= 32);
+        assert_eq!(args.labels, LabelDensity::Rich);
+    }
+
+    #[test]
+    fn labels_flag_does_not_change_performant_plan() {
+        let off = Args::try_parse_from(["pycelium-win", "--labels", "off"]).expect("parse");
+        let def = Args::try_parse_from(["pycelium-win"]).expect("parse");
+        let a = MemoryPlan::from_args(&off);
+        let b = MemoryPlan::from_args(&def);
+        assert_eq!(a.gpu_width, b.gpu_width);
+        assert_eq!(a.gpu_agents, b.gpu_agents);
+        assert_eq!(a.gpu_depth, b.gpu_depth);
+        assert_eq!(off.labels, LabelDensity::Off);
+        assert_eq!(def.labels, LabelDensity::Rich);
+        assert_eq!(def.preset, Preset::Performant);
+    }
+
+    #[test]
+    fn label_density_cycles_and_keeps_presets_untouched() {
+        assert_eq!(LabelDensity::Rich.cycle(), LabelDensity::Sparse);
+        assert_eq!(LabelDensity::Sparse.cycle(), LabelDensity::Off);
+        assert_eq!(LabelDensity::Off.cycle(), LabelDensity::Rich);
+        assert_eq!(LabelDensity::Off.as_f32(), 0.0);
+        assert_eq!(LabelDensity::Sparse.as_f32(), 1.0);
+        assert_eq!(LabelDensity::Rich.as_f32(), 2.0);
+        let beast = Args {
+            preset: Preset::Beast,
+            ram_gb: None,
+            resolution: None,
+            depth: None,
+            agents: None,
+            food: 28,
+            steps: 1,
+            vsync: false,
+            drift: false,
+            bench: None,
+            labels: LabelDensity::Off,
+        };
+        let plan = MemoryPlan::from_args(&beast);
+        assert!(plan.gpu_agents >= 1_000);
+        assert_eq!(beast.labels, LabelDensity::Off);
     }
 }

--- a/pycelium-win/src/gpu.rs
+++ b/pycelium-win/src/gpu.rs
@@ -387,6 +387,10 @@ impl MyceliumGpu {
         eye: [f32; 3],
         target: [f32; 3],
         fps: f32,
+        cursor: [f32; 2],
+        label_density: f32,
+        label_fade: f32,
+        has_picked: bool,
     ) {
         let present = PresentUniforms {
             width: self.width,
@@ -407,7 +411,7 @@ impl MyceliumGpu {
             internal_c: 0.0,
             enzyme: 0.0,
             organic: 0.0,
-            selected_id: self.last_pick as f32,
+            selected_id: if has_picked { 1.0 } else { 0.0 },
             selected_lineage: 0.0,
             selected_age: 0.0,
             selected_reserve: 0.0,
@@ -419,6 +423,7 @@ impl MyceliumGpu {
             slice_zoom: self.slice.zoom,
             slice_ox: self.slice.ox,
             slice_oy: self.slice.oy,
+            hud_ui: [cursor[0], cursor[1], label_density, label_fade],
         };
         queue.write_buffer(&self.present_buf, 0, bytemuck::bytes_of(&present));
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
@@ -533,6 +538,22 @@ fn storage_entry(
             min_binding_size: None,
         },
         count: None,
+    }
+}
+
+#[cfg(test)]
+mod shader_tests {
+    #[test]
+    fn present_wgsl_parses_and_validates() {
+        let src = include_str!("shaders/present.wgsl");
+        let module = naga::front::wgsl::parse_str(src).expect("parse present.wgsl");
+        let mut validator = naga::valid::Validator::new(
+            naga::valid::ValidationFlags::all(),
+            naga::valid::Capabilities::default(),
+        );
+        validator
+            .validate(&module)
+            .expect("present.wgsl should validate");
     }
 }
 

--- a/pycelium-win/src/main.rs
+++ b/pycelium-win/src/main.rs
@@ -16,7 +16,7 @@ use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop, EventLoopProxy}
 use winit::keyboard::{Key, NamedKey};
 use winit::window::{Window, WindowId};
 
-use crate::config::{Args, MemoryPlan};
+use crate::config::{Args, LabelDensity, MemoryPlan};
 use crate::gpu::{GpuDevice, MyceliumGpu};
 use crate::memory::HostWorld;
 use crate::types::SimUniforms;
@@ -60,8 +60,11 @@ struct Runtime {
     fps: f32,
     orbit: Orbit,
     pending_pick: bool,
+    has_picked: bool,
     cursor: (f32, f32),
     shift: bool,
+    labels: LabelDensity,
+    label_fade: f32,
 }
 
 struct App {
@@ -69,6 +72,7 @@ struct App {
     plan: MemoryPlan,
     world: Option<HostWorld>,
     runtime: Option<Runtime>,
+    labels: LabelDensity,
 }
 
 fn main() -> Result<()> {
@@ -79,6 +83,7 @@ fn main() -> Result<()> {
     println!("{}", plan.describe());
 
     let world = HostWorld::commit(&plan)?;
+    let labels = args.labels;
 
     if let Some(frames) = args.bench {
         return run_bench(plan, world, frames);
@@ -90,6 +95,7 @@ fn main() -> Result<()> {
         plan,
         world: Some(world),
         runtime: None,
+        labels,
     };
     event_loop.run_app(&mut app)?;
     Ok(())
@@ -144,6 +150,7 @@ impl ApplicationHandler<AppAction> for App {
         let plan = self.plan.clone();
         let world = self.world.take().expect("host world");
         let vsync = plan.vsync;
+        let labels = self.labels;
 
         pollster::block_on(async move {
             let instance = wgpu::Instance::new(
@@ -197,8 +204,11 @@ impl ApplicationHandler<AppAction> for App {
                     last: None,
                 },
                 pending_pick: false,
+                has_picked: false,
                 cursor: (0.5, 0.5),
                 shift: false,
+                labels,
+                label_fade: if labels == LabelDensity::Off { 0.0 } else { 1.0 },
             })));
         });
     }
@@ -218,6 +228,10 @@ impl ApplicationHandler<AppAction> for App {
                 );
                 println!("[ ] depth | ; ' thickness | , . XY field | arrows pan slab | Shift = coarse");
                 println!("Space pause | R reseed | F litter | D drift | Esc quit");
+                println!(
+                    "Tab HUD labels ({}) | hover a meter to fade English | glyphs stay",
+                    self.runtime.as_ref().map(|r| r.labels.as_str()).unwrap_or("rich")
+                );
                 println!(
                     "HUD: FPS, tips, fusions, branches, C:N | bars | then slice Z / thickness / zoom% | selected tip"
                 );
@@ -349,6 +363,11 @@ impl ApplicationHandler<AppAction> for App {
                 }
                 match logical_key {
                     Key::Named(NamedKey::Escape) => event_loop.exit(),
+                    Key::Named(NamedKey::Tab) => {
+                        rt.labels = rt.labels.cycle();
+                        println!("HUD labels: {}", rt.labels.as_str());
+                        rt.window.request_redraw();
+                    }
                     Key::Named(NamedKey::Space) => rt.paused = !rt.paused,
                     Key::Character(c) if c.eq_ignore_ascii_case("r") => {
                         rt.sim.reseed(&rt.gpu.queue, &rt.world);
@@ -379,6 +398,7 @@ impl ApplicationHandler<AppAction> for App {
             }
             WindowEvent::RedrawRequested => {
                 if rt.pending_pick {
+                    rt.has_picked = true;
                     let (eye, target) = rt.orbit.eye_target();
                     let rd = click_dir(rt.cursor, rt.config.width, rt.config.height, eye, target);
                     let vol = [
@@ -414,6 +434,15 @@ impl ApplicationHandler<AppAction> for App {
                             .texture
                             .create_view(&wgpu::TextureViewDescriptor::default());
                         let (eye, target) = rt.orbit.eye_target();
+                        let fade_target = if rt.labels == LabelDensity::Off {
+                            0.0
+                        } else {
+                            1.0
+                        };
+                        rt.label_fade += (fade_target - rt.label_fade) * 0.22;
+                        if (rt.label_fade - fade_target).abs() < 0.01 {
+                            rt.label_fade = fade_target;
+                        }
                         rt.sim.render(
                             &rt.gpu.device,
                             &rt.gpu.queue,
@@ -423,6 +452,10 @@ impl ApplicationHandler<AppAction> for App {
                             eye,
                             target,
                             rt.fps,
+                            [rt.cursor.0, rt.cursor.1],
+                            rt.labels.as_f32(),
+                            rt.label_fade,
+                            rt.has_picked,
                         );
                         rt.window.pre_present_notify();
                         rt.gpu.queue.present(frame);

--- a/pycelium-win/src/shaders/present.wgsl
+++ b/pycelium-win/src/shaders/present.wgsl
@@ -308,11 +308,11 @@ fn paint_label(uv: vec2<f32>, origin: vec2<f32>, id: i32, alpha: f32, rgb: vec3<
     return out;
 }
 
-fn paint_callout(uv: vec2<f32>, from: vec2<f32>, to: vec2<f32>, alpha: f32, rgb: vec3<f32>) -> vec3<f32> {
+fn paint_callout(uv: vec2<f32>, src: vec2<f32>, dst: vec2<f32>, alpha: f32, rgb: vec3<f32>) -> vec3<f32> {
     if alpha < 0.55 {
         return rgb;
     }
-    let line = elbow(uv, from, to);
+    let line = elbow(uv, src, dst);
     return mix(rgb, vec3<f32>(0.86, 0.88, 0.84), line * (alpha - 0.55) * 0.9);
 }
 

--- a/pycelium-win/src/shaders/present.wgsl
+++ b/pycelium-win/src/shaders/present.wgsl
@@ -40,6 +40,7 @@ struct PresentUniforms {
     slice_zoom: f32,
     slice_ox: f32,
     slice_oy: f32,
+    hud_ui: vec4<f32>,
 }
 
 @group(0) @binding(0) var<uniform> u: PresentUniforms;
@@ -140,6 +141,181 @@ fn bar(uv: vec2<f32>, origin: vec2<f32>, fill: f32, rgb: vec3<f32>) -> vec3<f32>
     return body * edge;
 }
 
+fn px() -> vec2<f32> {
+    return vec2<f32>(1.0 / max(f32(u.out_w), 1.0), 1.0 / max(f32(u.out_h), 1.0));
+}
+
+// 5×5 mono capitals. Packed row-major, bit 0 = top-left. Space = 0, A–Z = 1–26, ':' = 27.
+fn letter_bits(ch: i32) -> u32 {
+    switch ch {
+        case 1: { return 0x0118FE2Eu; }  // A
+        case 2: { return 0x00F8BE2Fu; }  // B
+        case 3: { return 0x01E0843Eu; }  // C
+        case 4: { return 0x00F8C62Fu; }  // D
+        case 5: { return 0x01F0BC3Fu; }  // E
+        case 6: { return 0x0010BC3Fu; }  // F
+        case 7: { return 0x01E8E43Eu; }  // G
+        case 8: { return 0x0118FE31u; }  // H
+        case 9: { return 0x01F2109Fu; }  // I
+        case 10: { return 0x0064A11Cu; } // J
+        case 11: { return 0x01149D31u; } // K
+        case 12: { return 0x01F08421u; } // L
+        case 13: { return 0x0118D771u; } // M
+        case 14: { return 0x011CD671u; } // N
+        case 15: { return 0x00E8C62Eu; } // O
+        case 16: { return 0x0010BE2Fu; } // P
+        case 17: { return 0x01ECC62Eu; } // Q
+        case 18: { return 0x0114BE2Fu; } // R
+        case 19: { return 0x00F8383Eu; } // S
+        case 20: { return 0x0042109Fu; } // T
+        case 21: { return 0x00E8C631u; } // U
+        case 22: { return 0x00454631u; } // V
+        case 23: { return 0x011DD631u; } // W
+        case 24: { return 0x01151151u; } // X
+        case 25: { return 0x00421151u; } // Y
+        case 26: { return 0x01F1111Fu; } // Z
+        case 27: { return 0x00020080u; } // :
+        default: { return 0u; }
+    }
+}
+
+fn letter(cell: vec2<f32>, ch: i32) -> f32 {
+    if ch <= 0 { return 0.0; }
+    let p = vec2<i32>(i32(floor(cell.x * 5.0)), i32(floor((1.0 - cell.y) * 5.0)));
+    if p.x < 0 || p.x > 4 || p.y < 0 || p.y > 4 { return 0.0; }
+    let bits = letter_bits(ch);
+    let bit = u32(p.y * 5 + p.x);
+    return f32((bits >> bit) & 1u);
+}
+
+// Short English names for the left HUD. -1 terminates a string of at most 8 glyphs.
+fn label_char(id: i32, slot: i32) -> i32 {
+    switch id {
+        case 0: { // FPS
+            switch slot { case 0: { return 6; } case 1: { return 16; } case 2: { return 19; } default: { return -1; } }
+        }
+        case 1: { // TIPS
+            switch slot { case 0: { return 20; } case 1: { return 9; } case 2: { return 16; } case 3: { return 19; } default: { return -1; } }
+        }
+        case 2: { // FUSIONS
+            switch slot { case 0: { return 6; } case 1: { return 21; } case 2: { return 19; } case 3: { return 9; } case 4: { return 15; } case 5: { return 14; } case 6: { return 19; } default: { return -1; } }
+        }
+        case 3: { // BRANCHES
+            switch slot { case 0: { return 2; } case 1: { return 18; } case 2: { return 1; } case 3: { return 14; } case 4: { return 3; } case 5: { return 8; } case 6: { return 5; } case 7: { return 19; } default: { return -1; } }
+        }
+        case 4: { // C:N
+            switch slot { case 0: { return 3; } case 1: { return 27; } case 2: { return 14; } default: { return -1; } }
+        }
+        case 5: { // HYPHA
+            switch slot { case 0: { return 8; } case 1: { return 25; } case 2: { return 16; } case 3: { return 8; } case 4: { return 1; } default: { return -1; } }
+        }
+        case 6: { // CORD
+            switch slot { case 0: { return 3; } case 1: { return 15; } case 2: { return 18; } case 3: { return 4; } default: { return -1; } }
+        }
+        case 7: { // SOL C
+            switch slot { case 0: { return 19; } case 1: { return 15; } case 2: { return 12; } case 3: { return 0; } case 4: { return 3; } default: { return -1; } }
+        }
+        case 8: { // SOL N
+            switch slot { case 0: { return 19; } case 1: { return 15; } case 2: { return 12; } case 3: { return 0; } case 4: { return 14; } default: { return -1; } }
+        }
+        case 9: { // ENZYME
+            switch slot { case 0: { return 5; } case 1: { return 14; } case 2: { return 26; } case 3: { return 25; } case 4: { return 13; } case 5: { return 5; } default: { return -1; } }
+        }
+        case 10: { // ORGANIC
+            switch slot { case 0: { return 15; } case 1: { return 18; } case 2: { return 7; } case 3: { return 1; } case 4: { return 14; } case 5: { return 9; } case 6: { return 3; } default: { return -1; } }
+        }
+        case 11: { // SLICE Z
+            switch slot { case 0: { return 19; } case 1: { return 12; } case 2: { return 9; } case 3: { return 3; } case 4: { return 5; } case 5: { return 0; } case 6: { return 26; } default: { return -1; } }
+        }
+        case 12: { // THICK
+            switch slot { case 0: { return 20; } case 1: { return 8; } case 2: { return 9; } case 3: { return 3; } case 4: { return 11; } default: { return -1; } }
+        }
+        case 13: { // ZOOM
+            switch slot { case 0: { return 26; } case 1: { return 15; } case 2: { return 15; } case 3: { return 13; } default: { return -1; } }
+        }
+        case 14: { // TIP
+            switch slot { case 0: { return 20; } case 1: { return 9; } case 2: { return 16; } default: { return -1; } }
+        }
+        case 15: { // LINEAGE
+            switch slot { case 0: { return 12; } case 1: { return 9; } case 2: { return 14; } case 3: { return 5; } case 4: { return 1; } case 5: { return 7; } case 6: { return 5; } default: { return -1; } }
+        }
+        case 16: { // AGE
+            switch slot { case 0: { return 1; } case 1: { return 7; } case 2: { return 5; } default: { return -1; } }
+        }
+        case 17: { // RESERVE
+            switch slot { case 0: { return 18; } case 1: { return 5; } case 2: { return 19; } case 3: { return 5; } case 4: { return 18; } case 5: { return 22; } case 6: { return 5; } default: { return -1; } }
+        }
+        case 18: { // PARAM
+            switch slot { case 0: { return 16; } case 1: { return 1; } case 2: { return 18; } case 3: { return 1; } case 4: { return 13; } default: { return -1; } }
+        }
+        default: { return -1; }
+    }
+}
+
+fn draw_label(uv: vec2<f32>, origin: vec2<f32>, id: i32) -> f32 {
+    let n = 8.0;
+    let local = (uv - origin) / vec2<f32>(0.0075 * n, 0.014);
+    if local.x < 0.0 || local.x > 1.0 || local.y < 0.0 || local.y > 1.0 {
+        return 0.0;
+    }
+    let slot = i32(floor(local.x * n));
+    let cell = vec2<f32>(fract(local.x * n), local.y);
+    let ch = label_char(id, slot);
+    if ch < 0 { return 0.0; }
+    return letter(cell, ch);
+}
+
+fn thin_frame(uv: vec2<f32>, r0: vec2<f32>, r1: vec2<f32>) -> f32 {
+    let p = px();
+    let inside = uv.x >= r0.x && uv.x <= r1.x && uv.y >= r0.y && uv.y <= r1.y;
+    let inner = uv.x >= r0.x + p.x && uv.x <= r1.x - p.x && uv.y >= r0.y + p.y && uv.y <= r1.y - p.y;
+    return select(0.0, 1.0, inside && !inner);
+}
+
+fn elbow(uv: vec2<f32>, a: vec2<f32>, b: vec2<f32>) -> f32 {
+    let p = px();
+    let h = abs(uv.y - a.y) <= p.y && uv.x >= min(a.x, b.x) && uv.x <= max(a.x, b.x);
+    let v = abs(uv.x - b.x) <= p.x && uv.y >= min(a.y, b.y) && uv.y <= max(a.y, b.y);
+    return select(0.0, 1.0, h || v);
+}
+
+fn row_alpha(cursor: vec2<f32>, y0: f32, y1: f32, density: f32, fade: f32, picked: bool) -> f32 {
+    if density < 0.5 || fade <= 0.0 {
+        return 0.0;
+    }
+    let in_panel = cursor.x < 0.26;
+    let mid = 0.5 * (y0 + y1);
+    let half = max(0.5 * (y1 - y0), 0.012);
+    let dy = abs(cursor.y - mid);
+    var hover = 0.0;
+    if in_panel {
+        hover = 1.0 - smoothstep(half, half + 0.028, dy);
+    }
+    let base = select(0.0, 0.32, density > 1.5);
+    let focus = select(base, max(base, 0.82), picked);
+    return clamp(max(focus, hover), 0.0, 1.0) * fade;
+}
+
+fn paint_label(uv: vec2<f32>, origin: vec2<f32>, id: i32, alpha: f32, rgb: vec3<f32>) -> vec3<f32> {
+    if alpha <= 0.004 {
+        return rgb;
+    }
+    let shadow = draw_label(uv, origin + px() * 2.0, id);
+    let ink = draw_label(uv, origin, id);
+    var out = rgb;
+    out = mix(out, vec3<f32>(0.0, 0.0, 0.0), shadow * alpha * 0.55);
+    out = mix(out, vec3<f32>(0.94, 0.95, 0.92), ink * alpha);
+    return out;
+}
+
+fn paint_callout(uv: vec2<f32>, from: vec2<f32>, to: vec2<f32>, alpha: f32, rgb: vec3<f32>) -> vec3<f32> {
+    if alpha < 0.55 {
+        return rgb;
+    }
+    let line = elbow(uv, from, to);
+    return mix(rgb, vec3<f32>(0.86, 0.88, 0.84), line * (alpha - 0.55) * 0.9);
+}
+
 @fragment
 fn fs_main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
     let res = vec2<f32>(f32(u.out_w), f32(u.out_h));
@@ -215,7 +391,8 @@ fn fs_main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
         rgb = mix(srgb, vec3<f32>(0.8, 0.8, 0.75), frame);
     }
 
-    // Telemetry panel.
+    // Telemetry panel. 3×5 glyphs stay; English is a fade-in overlay.
+    // Row map: docs/HUD_LEGEND.md
     if uv.x < 0.24 {
         rgb = mix(rgb, vec3<f32>(0.03, 0.035, 0.04), 0.78);
         var ink = 0.0;
@@ -256,6 +433,77 @@ fn fs_main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
         rgb = rgb + bar(uv, vec2<f32>(0.03, 0.44), f32(hud[7]) / 25000.0, vec3<f32>(0.55, 0.40, 0.85));
         rgb = rgb + bar(uv, vec2<f32>(0.03, 0.48), f32(hud[8]) / 20000.0, vec3<f32>(0.32, 0.70, 0.34));
         rgb = rgb + bar(uv, vec2<f32>(0.03, 0.52), f32(hud[9]) / 50000.0, vec3<f32>(0.45, 0.32, 0.18));
+
+        let cursor = u.hud_ui.xy;
+        let density = u.hud_ui.z;
+        let fade = clamp(u.hud_ui.w, 0.0, 1.0);
+        let picked = sid < 20000000u && u.selected_id > 0.0;
+        let chrome = row_alpha(cursor, 0.04, 0.96, density, fade, false) * 0.55;
+        rgb = mix(rgb, vec3<f32>(0.72, 0.74, 0.70), thin_frame(uv, vec2<f32>(0.008, 0.048), vec2<f32>(0.232, 0.288)) * chrome);
+        rgb = mix(rgb, vec3<f32>(0.72, 0.74, 0.70), thin_frame(uv, vec2<f32>(0.008, 0.300), vec2<f32>(0.232, 0.548)) * chrome);
+        rgb = mix(rgb, vec3<f32>(0.72, 0.74, 0.70), thin_frame(uv, vec2<f32>(0.008, 0.548), vec2<f32>(0.232, 0.682)) * chrome);
+        rgb = mix(rgb, vec3<f32>(0.72, 0.74, 0.70), thin_frame(uv, vec2<f32>(0.008, 0.688), vec2<f32>(0.232, 0.862)) * chrome);
+        rgb = mix(rgb, vec3<f32>(0.72, 0.74, 0.70), thin_frame(uv, vec2<f32>(0.008, 0.878), vec2<f32>(0.232, 0.938)) * chrome);
+
+        let a0 = row_alpha(cursor, 0.050, 0.100, density, fade, false);
+        let a1 = row_alpha(cursor, 0.105, 0.150, density, fade, false);
+        let a2 = row_alpha(cursor, 0.150, 0.185, density, fade, false);
+        let a3 = row_alpha(cursor, 0.185, 0.225, density, fade, false);
+        let a4 = row_alpha(cursor, 0.225, 0.280, density, fade, false);
+        let a5 = row_alpha(cursor, 0.305, 0.345, density, fade, false);
+        let a6 = row_alpha(cursor, 0.345, 0.385, density, fade, false);
+        let a7 = row_alpha(cursor, 0.385, 0.425, density, fade, false);
+        let a8 = row_alpha(cursor, 0.425, 0.465, density, fade, false);
+        let a9 = row_alpha(cursor, 0.465, 0.505, density, fade, false);
+        let a10 = row_alpha(cursor, 0.505, 0.545, density, fade, false);
+        let a11 = row_alpha(cursor, 0.545, 0.585, density, fade, false);
+        let a12 = row_alpha(cursor, 0.585, 0.625, density, fade, false);
+        let a13 = row_alpha(cursor, 0.625, 0.675, density, fade, false);
+        let a14 = row_alpha(cursor, 0.675, 0.725, density, fade, picked);
+        let a15 = row_alpha(cursor, 0.725, 0.765, density, fade, picked);
+        let a16 = row_alpha(cursor, 0.765, 0.805, density, fade, picked);
+        let a17 = row_alpha(cursor, 0.805, 0.855, density, fade, picked);
+        let a18 = row_alpha(cursor, 0.855, 0.940, density, fade, false);
+
+        rgb = paint_label(uv, vec2<f32>(0.068, 0.067), 0, a0, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.112, 0.127), 1, a1, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.098, 0.167), 2, a2, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.098, 0.207), 3, a3, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.084, 0.247), 4, a4, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.304), 5, a5, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.344), 6, a6, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.384), 7, a7, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.424), 8, a8, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.464), 9, a9, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.504), 10, a10, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.084, 0.567), 11, a11, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.070, 0.607), 12, a12, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.070, 0.647), 13, a13, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.112, 0.707), 14, a14, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.070, 0.747), 15, a15, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.098, 0.787), 16, a16, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.084, 0.827), 17, a17, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.118, 0.907), 18, a18, rgb);
+
+        rgb = paint_callout(uv, vec2<f32>(0.062, 0.074), vec2<f32>(0.066, 0.074), a0, rgb);
+        rgb = paint_callout(uv, vec2<f32>(0.104, 0.134), vec2<f32>(0.110, 0.134), a1, rgb);
+        rgb = paint_callout(uv, vec2<f32>(0.090, 0.174), vec2<f32>(0.096, 0.174), a2, rgb);
+        rgb = paint_callout(uv, vec2<f32>(0.090, 0.214), vec2<f32>(0.096, 0.214), a3, rgb);
+        rgb = paint_callout(uv, vec2<f32>(0.076, 0.254), vec2<f32>(0.082, 0.254), a4, rgb);
+        rgb = paint_callout(uv, vec2<f32>(0.028, 0.328), vec2<f32>(0.028, 0.311), a5, rgb);
+        rgb = paint_callout(uv, vec2<f32>(0.028, 0.368), vec2<f32>(0.028, 0.351), a6, rgb);
+        rgb = paint_callout(uv, vec2<f32>(0.028, 0.408), vec2<f32>(0.028, 0.391), a7, rgb);
+        rgb = paint_callout(uv, vec2<f32>(0.028, 0.448), vec2<f32>(0.028, 0.431), a8, rgb);
+        rgb = paint_callout(uv, vec2<f32>(0.028, 0.488), vec2<f32>(0.028, 0.471), a9, rgb);
+        rgb = paint_callout(uv, vec2<f32>(0.028, 0.528), vec2<f32>(0.028, 0.511), a10, rgb);
+        rgb = paint_callout(uv, vec2<f32>(0.076, 0.574), vec2<f32>(0.082, 0.574), a11, rgb);
+        rgb = paint_callout(uv, vec2<f32>(0.062, 0.614), vec2<f32>(0.068, 0.614), a12, rgb);
+        rgb = paint_callout(uv, vec2<f32>(0.062, 0.654), vec2<f32>(0.068, 0.654), a13, rgb);
+        rgb = paint_callout(uv, vec2<f32>(0.104, 0.714), vec2<f32>(0.110, 0.714), a14, rgb);
+        rgb = paint_callout(uv, vec2<f32>(0.062, 0.754), vec2<f32>(0.068, 0.754), a15, rgb);
+        rgb = paint_callout(uv, vec2<f32>(0.090, 0.794), vec2<f32>(0.096, 0.794), a16, rgb);
+        rgb = paint_callout(uv, vec2<f32>(0.076, 0.834), vec2<f32>(0.082, 0.834), a17, rgb);
+        rgb = paint_callout(uv, vec2<f32>(0.108, 0.914), vec2<f32>(0.116, 0.914), a18, rgb);
     }
 
     return vec4<f32>(rgb, 1.0);

--- a/pycelium-win/src/types.rs
+++ b/pycelium-win/src/types.rs
@@ -186,6 +186,8 @@ pub struct PresentUniforms {
     pub slice_zoom: f32,
     pub slice_ox: f32,
     pub slice_oy: f32,
+    /// xy = cursor UV, z = label density (0 off / 1 sparse / 2 rich), w = fade 0..1
+    pub hud_ui: [f32; 4],
 }
 
 /// Orthogonal section through the pedon. Depth is the plane; thickness is
@@ -237,3 +239,14 @@ impl SliceView {
 }
 
 pub const TEL_COUNT: usize = 16;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn present_uniforms_stay_16_byte_aligned() {
+        assert_eq!(std::mem::size_of::<PresentUniforms>() % 16, 0);
+        assert!(std::mem::size_of::<PresentUniforms>() >= 160);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The left telemetry HUD in `pycelium-win` was glyphs-only: 3×5 bitmap digits and unlabeled teal→brown bars. This keeps those digits (and the organic present look) and adds analysis-knowledge-core style English captions in the present pass.

## Before
- Left column: cryptic 3×5 numbers + unlabeled bars
- No hover / density / legend
- Console line was the only decoder

## After
- Same glyph positions and 3×5 bitmaps
- Short white 5×5 mono labels (`FPS`, `TIPS`, `FUSIONS`, `BRANCHES`, `C:N`, `HYPHA`, `CORD`, `SOL C`, `SOL N`, `ENZYME`, `ORGANIC`, `SLICE Z`, `THICK`, `ZOOM`, `TIP`, `LINEAGE`, `AGE`, `RESERVE`, `PARAM`)
- Rich density (default): labels at low opacity, fade up on hover or after a tip pick
- **Tab** cycles `rich → sparse → off → rich` (global fade). `--labels sparse|off` sets startup mode
- Thin 1px group frames, optional elbow ticks, 2px pixelated drop shadow (no blur)
- Legend: [docs/HUD_LEGEND.md](docs/HUD_LEGEND.md) — map verified against `present.wgsl` / `hud_reduce` (not just the brief)

## Untouched
- Beast / performant / demo memory plans (`--labels` is UI-only; covered by a unit test)
- Headless `--bench`
- Mycelium Engine (not in this repo)
- Sim / grow / diffuse shaders

## How to try
```bash
cargo run -p pycelium-win --release -- --preset demo
# Tab: density    hover a meter    click a tip
```

## Verified
```text
cargo test -p pycelium-win --locked
# 5 tests: MemoryPlan / beast, --labels does not change performant plan,
# density cycle, PresentUniforms 16-byte align, naga parse+validate of present.wgsl

cargo run -p pycelium-win -- --help   # --labels rich|sparse|off
```
This environment has no GPU adapter, so the interactive window was not screenshotted. `--bench` still takes the headless path and fails only on missing adapter (same as before).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8bb4aabb-3744-4631-bbf8-fd474ba1ec7b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bb4aabb-3744-4631-bbf8-fd474ba1ec7b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

