### PR TITLE
Face-aligned slice export + readable HUD labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ docs/_build/
 target/
 *.pdb
 
+# Mesocosm slice captures
+exports/
+
 # IPython Notebook
 .ipynb_checkpoints
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,6 +425,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,10 +593,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+
+[[package]]
+name = "flate2"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide 0.9.1",
+ "zlib-rs",
+]
 
 [[package]]
 name = "foldhash"
@@ -789,6 +824,12 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
@@ -1002,6 +1043,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1495,6 +1556,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide 0.8.9",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1578,9 +1652,12 @@ dependencies = [
  "env_logger",
  "log",
  "naga",
+ "png",
  "pollster",
  "rand",
  "rayon",
+ "serde",
+ "serde_json",
  "wgpu",
  "winit",
 ]
@@ -1869,10 +1946,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
@@ -2891,3 +2987,15 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ python pycelium.py
 
 ### GPU mesocosm (`pycelium-win`)
 
-Windows / wgpu 3D pedon. Left telemetry HUD keeps the cryptic **3×5 bitmap digits** and fades in short English names (rich density by default; **Tab** cycles rich / sparse / off). Legend: [docs/HUD_LEGEND.md](docs/HUD_LEGEND.md). Face-aligned **slice export** (`E` capture, `Enter` write PNG/JSON/SVG): [docs/SLICE_EXPORT.md](docs/SLICE_EXPORT.md).
+Windows / wgpu 3D pedon. Left telemetry HUD uses **white sans-serif English** plus a color readout box per row (rich by default; **Tab** cycles rich / sparse / off). Small 3×5 digits stay on the right. Legend: [docs/HUD_LEGEND.md](docs/HUD_LEGEND.md). Face-aligned **slice export** (`E` capture, `Enter` write PNG/JSON/SVG): [docs/SLICE_EXPORT.md](docs/SLICE_EXPORT.md).
 
 ```bash
 cargo run -p pycelium-win --release -- --preset demo

--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ python pycelium.py
 
 ### GPU mesocosm (`pycelium-win`)
 
-Windows / wgpu 3D pedon. Left telemetry HUD keeps the cryptic **3×5 bitmap digits** and fades in short English names (rich density by default; **Tab** cycles rich / sparse / off). Legend: [docs/HUD_LEGEND.md](docs/HUD_LEGEND.md).
+Windows / wgpu 3D pedon. Left telemetry HUD keeps the cryptic **3×5 bitmap digits** and fades in short English names (rich density by default; **Tab** cycles rich / sparse / off). Legend: [docs/HUD_LEGEND.md](docs/HUD_LEGEND.md). Face-aligned **slice export** (`E` capture, `Enter` write PNG/JSON/SVG): [docs/SLICE_EXPORT.md](docs/SLICE_EXPORT.md).
 
 ```bash
 cargo run -p pycelium-win --release -- --preset demo
 # Tab: label density    hover a meter to focus    --labels sparse|off
+# E: capture slice    C: 2D/rich    hover a cube face to snap    Enter: export
 # --bench N is headless and does not open the HUD
 ```
 
@@ -45,6 +46,7 @@ labeled **EXAMPLE** and are not measurements.
 | `pycelium.py` | CLI toy |
 | `pycelium-win/` | GPU mesocosm + telemetry HUD |
 | `docs/HUD_LEGEND.md` | Left HUD map (glyphs + English) |
+| `docs/SLICE_EXPORT.md` | Capture cutter + export formats |
 | `docs/EXPERIMENT_LOG.md` | How to record a logged trial |
 | `docs/experiments/` | CSV / JSONL schema + EXAMPLE rows |
 | `README.rst` | Original short readme |

--- a/docs/HUD_LEGEND.md
+++ b/docs/HUD_LEGEND.md
@@ -68,6 +68,8 @@ After a pick, sparse mode keeps this block readable.
 
 Slots: chemotropism, nitrotropism, autotropism, persistence, maintenance, enzyme_k, branch_cost, extension. Keys `1–8` select, `-` / `=` nudge.
 
+Slice **export** (face-aligned 2D squash / rich box) is a separate capture mode (`E`). It does not change these HUD rows. See [SLICE_EXPORT.md](SLICE_EXPORT.md).
+
 ## Inset (right)
 
 The orthogonal slab inset is **not** part of the left HUD. It shows hypha + soluble C in the current Z slab, framed, with zoom/pan.

--- a/docs/HUD_LEGEND.md
+++ b/docs/HUD_LEGEND.md
@@ -1,70 +1,72 @@
 # Pycelium-win telemetry HUD
 
-Left-column overlay drawn in `pycelium-win/src/shaders/present.wgsl`. The **3×5 bitmap digits stay**; English is a fade-in mono caption next to each meter.
+Left-column overlay drawn in `pycelium-win/src/shaders/present.wgsl`. **English is the readable layer**: white geometric sans-serif captions (stroked atlas, not the old 5×5 bitmaps). Each row has a **color readout box** whose fill tracks that meter. Small 3×5 digit clusters sit on the right as optional dense telemetry.
 
-Default density is **rich**: names sit at low opacity, then fade up on hover or after a tip pick. **Tab** cycles `rich → sparse → off → rich`. `--labels sparse|off` sets the startup mode. Bench mode (`--bench`) never opens a window and is unchanged.
+Default density is **rich**: names are fully visible. **Tab** cycles `rich → sparse → off → rich`. `--labels sparse|off` sets the startup mode. Bench mode (`--bench`) never opens a window and is unchanged.
+
+The previous 5×5 captions were sampled with a Y flip against top-left bit packing, so they looked inverted / noisy. The atlas in `hud_font.rs` is built upright (`cell.y = 0` is the top of the letter).
 
 ## House chrome
 
-- White 5×5 mono captions (not a replacement for the alien 3×5 glyphs)
+- White sans-serif captions (system-UI / grotesque style)
+- Color box at the left of every row (always drawn, including `off`)
 - Thin 1-pixel frames around census / fields / slice / tip / param groups
-- Optional elbow ticks on the focused row
-- Tight 2-pixel drop shadow (no blur)
-- Density dial: rich (default), sparse (hover/pick only), off (glyphs only)
+- Tight 1–2 pixel drop shadow on type (no blur)
+- Density dial: rich (default, full opacity), sparse (hover/pick only), off (boxes + bars + small digits)
 
-## Census (top glyphs)
+## Census (top)
 
-| Row (UV y) | Glyph | English | Source |
-|------------|-------|---------|--------|
-| 0.06 | 3 digits | `FPS` | present uniform `fps` |
-| 0.12 | 6 digits | `TIPS` | `hud[0]` live apical tips |
-| 0.16 | 5 digits | `FUSIONS` | `hud[1]` anastomosis events |
-| 0.20 | 5 digits | `BRANCHES` | `hud[2]` branch births |
-| 0.24 | 4 digits | `C:N` | `hud[6] / hud[7]` soluble carbon : nitrogen |
+| Row (UV y) | Box | English | Small digits | Source |
+|------------|-----|---------|--------------|--------|
+| 0.06 | ice | `FPS` | 3 | present uniform `fps` |
+| 0.10 | teal | `TIPS` | 6 | `hud[0]` live apical tips |
+| 0.14 | amber | `FUSIONS` | 5 | `hud[1]` anastomosis events |
+| 0.18 | green | `BRANCHES` | 5 | `hud[2]` branch births |
+| 0.22 | rust | `C:N` | 4 | `hud[6] / hud[7]` soluble carbon : nitrogen |
 
 `hud[3]` is an internal growth accumulator and is **not** drawn.
 
 ## Field bars (teal → brown)
 
-Fill is a strided voxel census (`hud_reduce`, every 4th cell). Color matches the volume look.
+Fill is a strided voxel census (`hud_reduce`, every 4th cell). The box and bar share a color family; box brightness follows fill.
 
 | Bar y | English | Color | Buffer / scale |
 |-------|---------|-------|----------------|
-| 0.32 | `HYPHA` | teal `0.55, 0.92, 0.82` | `hud[4]` biomass / 80000 |
-| 0.36 | `CORD` | gold `0.95, 0.72, 0.28` | `hud[5]` internal C / 40000 |
+| 0.31 | `HYPHA` | teal `0.55, 0.92, 0.82` | `hud[4]` biomass / 80000 |
+| 0.35 | `CORD` | amber `0.95, 0.72, 0.28` | `hud[5]` internal C / 40000 |
 | 0.40 | `SOL C` | rust `0.78, 0.42, 0.10` | `hud[6]` soluble C / 40000 |
 | 0.44 | `SOL N` | violet `0.55, 0.40, 0.85` | `hud[7]` soluble N / 25000 |
 | 0.48 | `ENZYME` | green `0.32, 0.70, 0.34` | `hud[8]` exoenzyme / 20000 |
 | 0.52 | `ORGANIC` | brown `0.45, 0.32, 0.18` | `hud[9]` uncleaved polymer / 50000 |
 
-## Slice (lower-middle glyphs)
+## Slice (lower-middle)
 
-| Row | Glyph | English | Meaning |
-|-----|-------|---------|---------|
-| 0.56 | 4 digits | `SLICE Z` | orthogonal slab depth (voxels) |
-| 0.60 | 3 digits | `THICK` | slab thickness |
-| 0.64 | 3 digits | `ZOOM` | XY field as percent (`zoom * 100`) |
+| Row | Box | English | Small digits | Meaning |
+|-----|-----|---------|--------------|---------|
+| 0.56 | warm | `SLICE Z` | 4 | orthogonal slab depth (voxels) |
+| 0.60 | warm | `THICK` | 3 | slab thickness |
+| 0.64 | warm | `ZOOM` | 3 | XY field as percent (`zoom * 100`) |
 
 Keys: `[ ]` depth, `; '` thickness, `, .` zoom, arrows pan. Shift = coarse.
 
 ## Selected tip
 
-Click in the volume to pick the nearest live tip. `hud[10]` is the pick distance key (not drawn). `hud[11]` is the tip id.
+Click in the volume to pick the nearest live tip. `hud[10]` is the pick distance key (not drawn). `hud[11]` is the tip id. Boxes brighten after a pick.
 
-| Row | Glyph | English | Meaning |
-|-----|-------|---------|---------|
-| 0.70 | 6 digits | `TIP` | selected tip slot |
-| 0.74 | 3 digits | `LINEAGE` | inoculum / colony id |
-| 0.78 | 5 digits | `AGE` | tip age |
-| 0.82 | 4 digits | `RESERVE` | internal reserve × 100 |
+| Row | Box | English | Small digits | Meaning |
+|-----|-----|---------|--------------|---------|
+| 0.70 | teal | `TIP` | 6 | selected tip slot |
+| 0.74 | gold | `LINEAGE` | 3 | inoculum / colony id |
+| 0.78 | ice | `AGE` | 5 | tip age |
+| 0.82 | amber | `RESERVE` | 4 | internal reserve × 100 |
 
 After a pick, sparse mode keeps this block readable.
 
 ## Param knob
 
-| Row | Glyph | English | Meaning |
-|-----|-------|---------|---------|
-| 0.90 | 1 + 4 digits | `PARAM` | slot `1–8` and value × 100 |
+| Row | Box | English | Small digits | Meaning |
+|-----|-----|---------|--------------|---------|
+| 0.90 | ice | `PARAM` | 1 + 4 | slot `1–8` and value × 100 |
 
 Slots: chemotropism, nitrotropism, autotropism, persistence, maintenance, enzyme_k, branch_cost, extension. Keys `1–8` select, `-` / `=` nudge.
 

--- a/docs/SLICE_EXPORT.md
+++ b/docs/SLICE_EXPORT.md
@@ -1,0 +1,61 @@
+# Slice export + cutter
+
+Capture a face-aligned plane (or a thin box) from the GPU mesocosm and write **PNG + JSON + SVG** into `exports/` (override with `--export-dir`). No mesh or voxel conversion — density images, a mask, optional heightmap, and a small JSON record.
+
+Orbit, tip pick, HUD glyphs/labels, and **Tab** label density are unchanged. Capture is a separate mode.
+
+## Enter / leave
+
+| Key | Action |
+|-----|--------|
+| `E` | Toggle capture mode |
+| `C` | Cycle **2D squash** ↔ **rich box** (while capturing) |
+| `Enter` | Write files (timestamped stem) |
+| `Esc` | Leave capture (quit only when capture is off) |
+
+Mouse move positions the cutter through the cube. Left-drag still orbits unless you grab a slider handle. Click-to-pick is disabled while capturing.
+
+## Two capture modes
+
+1. **2D squash** (default) — same idea as the orange view slab: stack **N** nearby layers and keep the max biomass / soluble C on one plane. Starts at **1 layer** at the cursor. Drag the two-ended slider handles outward to thicken the bake.
+2. **Rich (3D box)** — two parallel planes forming a thin box you stretch (same slider). The PNG is still a density projection of that box; JSON also stores occupied volume samples `{u,v,t,d}` between the planes.
+
+## Face snap (Blender-like)
+
+The world is the unit cube. Hover near a **face center** (halfway) and the cutter axis snaps to that face’s normal:
+
+- Top / bottom (`±Z`) → horizontal slice (XY)
+- Side faces (`±X` / `±Y`) → **vertical** slice, so upright structures can be captured
+
+Hover a **face mid-edge** to rotate **90° on the free axis** (top-face left/right mid-edge → vertical X; top-face front/back mid-edge → vertical Y). The orange preview plane/box and a wash on the snapped faces show the alignment.
+
+`X` cycles axis by hand if snap misses. `Y` cycles the optional heightmap axis (and turns heightmap export on). `H` toggles writing the heightmap PNG.
+
+## Thickness
+
+- Bottom **two-ended slider**: center follows cursor depth along the snapped axis; drag either handle to grow N / box thickness (always symmetric).
+- **Shift + wheel** nudges thickness in voxels.
+
+View-slice keys (`[ ]` depth, `; '` thickness, `, .` zoom, arrows pan) still drive the existing Z slab / inset, not the cutter.
+
+## Files
+
+Stem: `exports/pycelium_<YYYYMMDD_HHMMSS>_<axis>_<squash|rich>.*`
+
+| File | Contents |
+|------|----------|
+| `.png` | Density / biomass view (teal hypha + rust soluble C, same look as the inset) |
+| `_mask.png` | Greyscale density mask (max-normalized) for later texture / material use |
+| `_height.png` | Optional. Greyscale along the chosen domain axis (black↔white). `H` / `Y`. |
+| `.json` | `pycelium-slice-v1`: grid meta, axis, thickness, stats, `density_u8`, rich `samples` |
+| `.svg` | Marching-squares contours of high-density regions |
+
+## CLI
+
+```bash
+cargo run -p pycelium-win --release -- --preset demo
+# E enter capture   hover a face   C rich/2D   Enter write
+cargo run -p pycelium-win --release -- --export-dir D:\captures
+```
+
+`--export-dir` does not change RAM / GPU presets. `--bench` stays headless and does not export.

--- a/pycelium-win/Cargo.toml
+++ b/pycelium-win/Cargo.toml
@@ -14,8 +14,8 @@ anyhow = "1"
 bytemuck = { version = "1", features = ["derive"] }
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"
-image = { version = "0.25", default-features = false, features = ["png"] }
 log = "0.4"
+png = "0.17"
 pollster = "0.4"
 rand = "0.8"
 rayon = "1.10"

--- a/pycelium-win/Cargo.toml
+++ b/pycelium-win/Cargo.toml
@@ -14,10 +14,13 @@ anyhow = "1"
 bytemuck = { version = "1", features = ["derive"] }
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"
+image = { version = "0.25", default-features = false, features = ["png"] }
 log = "0.4"
 pollster = "0.4"
 rand = "0.8"
 rayon = "1.10"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 wgpu = "30"
 winit = "0.30"
 

--- a/pycelium-win/src/config.rs
+++ b/pycelium-win/src/config.rs
@@ -57,6 +57,10 @@ pub struct Args {
     /// English HUD label density. Tab cycles rich → sparse → off at runtime.
     #[arg(long, value_enum, default_value_t = LabelDensity::Rich)]
     pub labels: LabelDensity,
+
+    /// Directory for slice-export files (created on first capture).
+    #[arg(long, default_value = "exports")]
+    pub export_dir: String,
 }
 
 /// How loudly the left telemetry HUD speaks English.
@@ -231,6 +235,7 @@ mod tests {
             drift: false,
             bench: None,
             labels: LabelDensity::Rich,
+            export_dir: "exports".into(),
         };
         let plan = MemoryPlan::from_args(&args);
         assert!(plan.estimated_host_bytes > 1024 * 1024);
@@ -251,6 +256,19 @@ mod tests {
         assert_eq!(off.labels, LabelDensity::Off);
         assert_eq!(def.labels, LabelDensity::Rich);
         assert!(matches!(def.preset, Preset::Performant));
+        assert_eq!(def.export_dir, "exports");
+    }
+
+    #[test]
+    fn export_dir_flag_does_not_change_plan() {
+        let custom =
+            Args::try_parse_from(["pycelium-win", "--export-dir", "out/slices"]).expect("parse");
+        let def = Args::try_parse_from(["pycelium-win"]).expect("parse");
+        let a = MemoryPlan::from_args(&custom);
+        let b = MemoryPlan::from_args(&def);
+        assert_eq!(a.gpu_width, b.gpu_width);
+        assert_eq!(a.gpu_agents, b.gpu_agents);
+        assert_eq!(custom.export_dir, "out/slices");
     }
 
     #[test]
@@ -273,6 +291,7 @@ mod tests {
             drift: false,
             bench: None,
             labels: LabelDensity::Off,
+            export_dir: "exports".into(),
         };
         let plan = MemoryPlan::from_args(&beast);
         assert!(plan.gpu_agents >= 1_000);

--- a/pycelium-win/src/config.rs
+++ b/pycelium-win/src/config.rs
@@ -64,15 +64,15 @@ pub struct Args {
 }
 
 /// How loudly the left telemetry HUD speaks English.
-/// Cryptic 3×5 glyphs stay visible in every mode.
+/// Color readout boxes stay visible in every mode.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
 pub enum LabelDensity {
-    /// All meter names at low opacity; hover / pick fades them up.
+    /// White sans-serif names at full opacity.
     #[default]
     Rich,
     /// Names only on hover, pick, or the focused param row.
     Sparse,
-    /// Glyphs and bars only.
+    /// Color boxes, bars, and small 3×5 digits only — no English.
     Off,
 }
 

--- a/pycelium-win/src/cutter.rs
+++ b/pycelium-win/src/cutter.rs
@@ -43,14 +43,6 @@ impl Axis {
         }
     }
 
-    pub fn from_index(i: i32) -> Self {
-        match i.rem_euclid(3) {
-            0 => Self::X,
-            1 => Self::Y,
-            _ => Self::Z,
-        }
-    }
-
     pub fn size(self, w: u32, h: u32, d: u32) -> u32 {
         match self {
             Self::X => w,
@@ -519,7 +511,7 @@ mod tests {
     fn slider_handles_thicken_from_one_layer() {
         let mut c = Cutter::new(100);
         c.enter(50.0, 100);
-        assert_eq!(c.hit_handle((0.50, 0.93), 100.0), None);
+        // One-layer handles sit on the cursor; grabbing either starts the thicken.
         let hn = c.half_norm(100.0);
         let x_neg = SLIDER_X0 + (c.pos - hn) * (SLIDER_X1 - SLIDER_X0);
         assert_eq!(c.hit_handle((x_neg, 0.93), 100.0), Some(Handle::Neg));
@@ -528,6 +520,8 @@ mod tests {
         c.drag_handle((x_wide, 0.93), 100.0);
         assert!((c.half_vox - 10.0).abs() < 0.6);
         assert!(c.thickness_voxels() > 8.0);
+        let x_far = SLIDER_X0 + 0.02 * (SLIDER_X1 - SLIDER_X0);
+        assert_eq!(c.hit_handle((x_far, 0.93), 100.0), None);
     }
 
     #[test]

--- a/pycelium-win/src/cutter.rs
+++ b/pycelium-win/src/cutter.rs
@@ -1,0 +1,561 @@
+//! Capture-mode cutter: face-aligned plane / box and the two-ended thickness slider.
+//!
+//! The mesocosm is a unit cube. Hovering a face center snaps the cutter to that
+//! face's normal (horizontal or vertical). Hovering a face mid-edge rotates 90°
+//! onto the free axis so vertical structures can be captured, not only Z slabs.
+
+use std::fmt;
+
+/// World-space slider (UV) for the two-ended thickness control.
+pub const SLIDER_X0: f32 = 0.30;
+pub const SLIDER_X1: f32 = 0.70;
+pub const SLIDER_Y0: f32 = 0.900;
+pub const SLIDER_Y1: f32 = 0.958;
+const HANDLE_PAD: f32 = 0.018;
+const FACE_CENTER_SNAP: f32 = 0.20;
+const FACE_EDGE_SNAP: f32 = 0.14;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Axis {
+    X = 0,
+    Y = 1,
+    Z = 2,
+}
+
+impl Axis {
+    pub fn as_f32(self) -> f32 {
+        self as u8 as f32
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::X => "x",
+            Self::Y => "y",
+            Self::Z => "z",
+        }
+    }
+
+    pub fn cycle(self) -> Self {
+        match self {
+            Self::X => Self::Y,
+            Self::Y => Self::Z,
+            Self::Z => Self::X,
+        }
+    }
+
+    pub fn from_index(i: i32) -> Self {
+        match i.rem_euclid(3) {
+            0 => Self::X,
+            1 => Self::Y,
+            _ => Self::Z,
+        }
+    }
+
+    pub fn size(self, w: u32, h: u32, d: u32) -> u32 {
+        match self {
+            Self::X => w,
+            Self::Y => h,
+            Self::Z => d,
+        }
+    }
+
+    /// Plane axes (u, v) for a slice whose normal is `self`.
+    pub fn plane_uv(self) -> (Self, Self) {
+        match self {
+            Self::X => (Self::Y, Self::Z),
+            Self::Y => (Self::X, Self::Z),
+            Self::Z => (Self::X, Self::Y),
+        }
+    }
+}
+
+impl fmt::Display for Axis {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CaptureMode {
+    /// Max-project N layers onto one plane (starts at 1 layer).
+    Squash2D,
+    /// Thin box between two parallel planes; JSON keeps the volume slab.
+    RichBox,
+}
+
+impl CaptureMode {
+    pub fn cycle(self) -> Self {
+        match self {
+            Self::Squash2D => Self::RichBox,
+            Self::RichBox => Self::Squash2D,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Squash2D => "squash",
+            Self::RichBox => "rich",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Handle {
+    Neg,
+    Pos,
+}
+
+#[derive(Clone, Debug)]
+pub struct Cutter {
+    pub active: bool,
+    pub mode: CaptureMode,
+    pub axis: Axis,
+    /// Normalized 0..1 position along `axis`.
+    pub pos: f32,
+    /// Half-thickness in voxels. 0.5 = one layer at the cursor.
+    pub half_vox: f32,
+    pub snapped: bool,
+    pub dragging: Option<Handle>,
+    pub export_heightmap: bool,
+    pub heightmap_axis: Axis,
+}
+
+impl Cutter {
+    pub fn new(depth: u32) -> Self {
+        let z0 = (depth as f32 * 0.35).clamp(1.0, (depth as f32 - 2.0).max(1.0));
+        let pos = if depth == 0 {
+            0.35
+        } else {
+            z0 / depth as f32
+        };
+        Self {
+            active: false,
+            mode: CaptureMode::Squash2D,
+            axis: Axis::Z,
+            pos,
+            half_vox: 0.5,
+            snapped: false,
+            dragging: None,
+            export_heightmap: false,
+            heightmap_axis: Axis::Z,
+        }
+    }
+
+    pub fn enter(&mut self, slice_z: f32, depth: u32) {
+        self.active = true;
+        self.dragging = None;
+        self.axis = Axis::Z;
+        self.snapped = false;
+        self.half_vox = 0.5;
+        if depth > 0 {
+            self.pos = (slice_z / depth as f32).clamp(0.0, 1.0);
+        }
+        self.heightmap_axis = self.axis;
+    }
+
+    pub fn leave(&mut self) {
+        self.active = false;
+        self.dragging = None;
+        self.snapped = false;
+    }
+
+    pub fn toggle(&mut self, slice_z: f32, depth: u32) {
+        if self.active {
+            self.leave();
+        } else {
+            self.enter(slice_z, depth);
+        }
+    }
+
+    pub fn cycle_mode(&mut self) {
+        self.mode = self.mode.cycle();
+    }
+
+    pub fn cycle_axis(&mut self) {
+        self.axis = self.axis.cycle();
+        self.snapped = false;
+        self.heightmap_axis = self.axis;
+    }
+
+    pub fn cycle_heightmap_axis(&mut self) {
+        self.heightmap_axis = self.heightmap_axis.cycle();
+        self.export_heightmap = true;
+    }
+
+    pub fn thickness_voxels(&self) -> f32 {
+        (self.half_vox * 2.0).max(1.0)
+    }
+
+    pub fn half_norm(&self, axis_size: f32) -> f32 {
+        if axis_size <= 0.0 {
+            return 0.0;
+        }
+        (self.half_vox / axis_size).clamp(0.0, 0.5)
+    }
+
+    pub fn clamp_half(&mut self, axis_size: f32) {
+        let max_half = (axis_size * 0.5).max(0.5);
+        self.half_vox = self.half_vox.clamp(0.5, max_half);
+        let hn = self.half_norm(axis_size);
+        self.pos = self.pos.clamp(hn, 1.0 - hn);
+    }
+
+    pub fn nudge_half(&mut self, delta_vox: f32, axis_size: f32) {
+        self.half_vox += delta_vox;
+        self.clamp_half(axis_size);
+    }
+
+    /// Packed present uniform: axis, pos, half_vox, mode(+0.5 if snapped).
+    pub fn present_vec(&self) -> [f32; 4] {
+        if !self.active {
+            return [2.0, self.pos, 0.5, 0.0];
+        }
+        let mode = match self.mode {
+            CaptureMode::Squash2D => 1.0,
+            CaptureMode::RichBox => 2.0,
+        };
+        let mode = if self.snapped { mode + 0.5 } else { mode };
+        [self.axis.as_f32(), self.pos, self.half_vox, mode]
+    }
+
+    pub fn describe(&self) -> String {
+        format!(
+            "CAPTURE {} {} @ {:.0}%  thick {:.0}  heightmap {}/{}  Enter write  Esc leave",
+            self.mode.as_str(),
+            self.axis,
+            self.pos * 100.0,
+            self.thickness_voxels(),
+            if self.export_heightmap { "on" } else { "off" },
+            self.heightmap_axis
+        )
+    }
+
+    pub fn hit_handle(&self, uv: (f32, f32), axis_size: f32) -> Option<Handle> {
+        if !self.active || !in_slider_band(uv) {
+            return None;
+        }
+        let hn = self.half_norm(axis_size);
+        let neg = self.pos - hn;
+        let pos = self.pos + hn;
+        let t = slider_t(uv.0);
+        if (t - neg).abs() <= HANDLE_PAD {
+            return Some(Handle::Neg);
+        }
+        if (t - pos).abs() <= HANDLE_PAD {
+            return Some(Handle::Pos);
+        }
+        None
+    }
+
+    pub fn drag_handle(&mut self, uv: (f32, f32), axis_size: f32) {
+        let Some(handle) = self.dragging else {
+            return;
+        };
+        let t = slider_t(uv.0);
+        let half_norm = match handle {
+            Handle::Neg => (self.pos - t).abs(),
+            Handle::Pos => (t - self.pos).abs(),
+        };
+        self.half_vox = (half_norm * axis_size).max(0.5);
+        self.clamp_half(axis_size);
+    }
+
+    /// Mouse-move: snap axis from cube-face hover and place the plane at ray depth.
+    pub fn track_pointer(&mut self, eye: [f32; 3], dir: [f32; 3], axis_size: f32) {
+        if !self.active || self.dragging.is_some() {
+            return;
+        }
+        let Some(seg) = ray_cube_segment(eye, dir) else {
+            self.snapped = false;
+            return;
+        };
+        if let Some(axis) = snap_axis_from_segment(eye, dir, seg) {
+            self.axis = axis;
+            self.snapped = true;
+            self.heightmap_axis = axis;
+        } else {
+            self.snapped = false;
+        }
+        let mid = segment_midpoint(eye, dir, seg);
+        self.pos = axis_component(mid, self.axis).clamp(0.0, 1.0);
+        self.clamp_half(axis_size);
+    }
+}
+
+fn in_slider_band(uv: (f32, f32)) -> bool {
+    uv.0 >= SLIDER_X0 - 0.02
+        && uv.0 <= SLIDER_X1 + 0.02
+        && uv.1 >= SLIDER_Y0 - 0.01
+        && uv.1 <= SLIDER_Y1 + 0.01
+}
+
+fn slider_t(x: f32) -> f32 {
+    ((x - SLIDER_X0) / (SLIDER_X1 - SLIDER_X0)).clamp(0.0, 1.0)
+}
+
+fn axis_component(p: [f32; 3], axis: Axis) -> f32 {
+    match axis {
+        Axis::X => p[0],
+        Axis::Y => p[1],
+        Axis::Z => p[2],
+    }
+}
+
+fn segment_midpoint(ro: [f32; 3], rd: [f32; 3], seg: (f32, f32)) -> [f32; 3] {
+    let t = 0.5 * (seg.0.max(0.0) + seg.1);
+    [
+        ro[0] + rd[0] * t,
+        ro[1] + rd[1] * t,
+        ro[2] + rd[2] * t,
+    ]
+}
+
+/// Ray vs unit cube. Returns (tmin, tmax) when the segment intersects.
+pub fn ray_cube_segment(ro: [f32; 3], rd: [f32; 3]) -> Option<(f32, f32)> {
+    let mut tmin = f32::NEG_INFINITY;
+    let mut tmax = f32::INFINITY;
+    for i in 0..3 {
+        if rd[i].abs() < 1e-8 {
+            if ro[i] < 0.0 || ro[i] > 1.0 {
+                return None;
+            }
+            continue;
+        }
+        let mut t0 = (0.0 - ro[i]) / rd[i];
+        let mut t1 = (1.0 - ro[i]) / rd[i];
+        if t0 > t1 {
+            std::mem::swap(&mut t0, &mut t1);
+        }
+        tmin = tmin.max(t0);
+        tmax = tmax.min(t1);
+        if tmax < tmin {
+            return None;
+        }
+    }
+    if tmax < 0.0 {
+        return None;
+    }
+    Some((tmin, tmax))
+}
+
+fn point_on(ro: [f32; 3], rd: [f32; 3], t: f32) -> [f32; 3] {
+    [
+        ro[0] + rd[0] * t,
+        ro[1] + rd[1] * t,
+        ro[2] + rd[2] * t,
+    ]
+}
+
+fn face_from_point(p: [f32; 3]) -> Option<(Axis, bool)> {
+    const EPS: f32 = 2e-3;
+    let mut best = None;
+    let mut best_d = EPS;
+    let faces = [
+        (Axis::X, false, p[0]),
+        (Axis::X, true, 1.0 - p[0]),
+        (Axis::Y, false, p[1]),
+        (Axis::Y, true, 1.0 - p[1]),
+        (Axis::Z, false, p[2]),
+        (Axis::Z, true, 1.0 - p[2]),
+    ];
+    for (axis, pos, dist) in faces {
+        if dist <= best_d {
+            best_d = dist;
+            best = Some((axis, pos));
+        }
+    }
+    best
+}
+
+fn face_uv(p: [f32; 3], axis: Axis) -> (f32, f32) {
+    match axis {
+        Axis::X => (p[1].clamp(0.0, 1.0), p[2].clamp(0.0, 1.0)),
+        Axis::Y => (p[0].clamp(0.0, 1.0), p[2].clamp(0.0, 1.0)),
+        Axis::Z => (p[0].clamp(0.0, 1.0), p[1].clamp(0.0, 1.0)),
+    }
+}
+
+/// Snap: face center → face normal; mid-edge → 90° onto the free axis.
+pub fn snap_axis_on_face(p: [f32; 3], face: Axis) -> Option<Axis> {
+    let (u, v) = face_uv(p, face);
+    let du = (u - 0.5).abs();
+    let dv = (v - 0.5).abs();
+    let center = (du * du + dv * dv).sqrt();
+    if center <= FACE_CENTER_SNAP {
+        return Some(face);
+    }
+    let (ua, va) = face.plane_uv();
+    // Mid of an edge parallel to U (v ≈ 0 or 1, u ≈ 0.5) → snap to V.
+    let edge_v = (dv - 0.5).abs() <= FACE_EDGE_SNAP && du <= FACE_EDGE_SNAP + 0.06;
+    if edge_v {
+        return Some(va);
+    }
+    // Mid of an edge parallel to V (u ≈ 0 or 1, v ≈ 0.5) → snap to U.
+    let edge_u = (du - 0.5).abs() <= FACE_EDGE_SNAP && dv <= FACE_EDGE_SNAP + 0.06;
+    if edge_u {
+        return Some(ua);
+    }
+    None
+}
+
+fn snap_axis_from_segment(ro: [f32; 3], rd: [f32; 3], seg: (f32, f32)) -> Option<Axis> {
+    let mut best: Option<(f32, Axis)> = None;
+    for t in [seg.0, seg.1] {
+        if t < -1e-4 {
+            continue;
+        }
+        let p = point_on(ro, rd, t);
+        let Some((face, _)) = face_from_point(p) else {
+            continue;
+        };
+        if let Some(axis) = snap_axis_on_face(p, face) {
+            let (u, v) = face_uv(p, face);
+            let score = (u - 0.5).abs() + (v - 0.5).abs();
+            if best.map(|(s, _)| score < s).unwrap_or(true) {
+                best = Some((score, axis));
+            }
+        }
+    }
+    best.map(|(_, a)| a)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_cutter_starts_idle_one_layer_on_z() {
+        let c = Cutter::new(64);
+        assert!(!c.active);
+        assert_eq!(c.mode, CaptureMode::Squash2D);
+        assert_eq!(c.axis, Axis::Z);
+        assert!((c.half_vox - 0.5).abs() < 1e-5);
+        assert!((c.thickness_voxels() - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn enter_follows_view_slice_depth() {
+        let mut c = Cutter::new(96);
+        c.enter(48.0, 96);
+        assert!(c.active);
+        assert!((c.pos - 0.5).abs() < 1e-5);
+        assert_eq!(c.axis, Axis::Z);
+    }
+
+    #[test]
+    fn toggle_and_esc_leave() {
+        let mut c = Cutter::new(64);
+        c.toggle(20.0, 64);
+        assert!(c.active);
+        c.toggle(20.0, 64);
+        assert!(!c.active);
+    }
+
+    #[test]
+    fn mode_and_axis_cycle() {
+        let mut c = Cutter::new(32);
+        c.cycle_mode();
+        assert_eq!(c.mode, CaptureMode::RichBox);
+        c.cycle_mode();
+        assert_eq!(c.mode, CaptureMode::Squash2D);
+        c.cycle_axis();
+        assert_eq!(c.axis, Axis::X);
+        c.cycle_axis();
+        assert_eq!(c.axis, Axis::Y);
+    }
+
+    #[test]
+    fn ray_hits_unit_cube() {
+        let seg = ray_cube_segment([-1.0, 0.5, 0.5], [1.0, 0.0, 0.0]).unwrap();
+        assert!((seg.0 - 1.0).abs() < 1e-4);
+        assert!((seg.1 - 2.0).abs() < 1e-4);
+        assert!(ray_cube_segment([-2.0, 2.0, 0.5], [1.0, 0.0, 0.0]).is_none());
+    }
+
+    #[test]
+    fn face_center_snaps_to_face_normal() {
+        assert_eq!(snap_axis_on_face([1.0, 0.5, 0.5], Axis::X), Some(Axis::X));
+        assert_eq!(snap_axis_on_face([0.5, 0.5, 1.0], Axis::Z), Some(Axis::Z));
+        assert_eq!(snap_axis_on_face([0.5, 0.0, 0.5], Axis::Y), Some(Axis::Y));
+    }
+
+    #[test]
+    fn face_mid_edge_snaps_ninety_degrees() {
+        // Top face (+Z): mid of X-aligned edge → Y (vertical).
+        assert_eq!(snap_axis_on_face([0.5, 0.0, 1.0], Axis::Z), Some(Axis::Y));
+        // Top face: mid of Y-aligned edge → X (vertical).
+        assert_eq!(snap_axis_on_face([0.0, 0.5, 1.0], Axis::Z), Some(Axis::X));
+        // +X face: mid of horizontal edge (z=0.5, y=0) → Y.
+        assert_eq!(snap_axis_on_face([1.0, 0.0, 0.5], Axis::X), Some(Axis::Y));
+        // +X face: mid of vertical edge (y=0.5, z=0) → Z (horizontal).
+        assert_eq!(snap_axis_on_face([1.0, 0.5, 0.0], Axis::X), Some(Axis::Z));
+    }
+
+    #[test]
+    fn face_corner_does_not_snap() {
+        assert_eq!(snap_axis_on_face([0.02, 0.02, 1.0], Axis::Z), None);
+    }
+
+    #[test]
+    fn hover_plus_x_face_center_snaps_vertical() {
+        let mut c = Cutter::new(64);
+        c.enter(32.0, 64);
+        c.track_pointer([-1.0, 0.5, 0.5], [1.0, 0.0, 0.0], 64.0);
+        assert_eq!(c.axis, Axis::X);
+        assert!(c.snapped);
+        assert!((c.pos - 0.5).abs() < 0.05);
+    }
+
+    #[test]
+    fn hover_top_face_center_snaps_horizontal() {
+        let mut c = Cutter::new(64);
+        c.enter(10.0, 64);
+        c.track_pointer([0.5, 0.5, 2.0], [0.0, 0.0, -1.0], 64.0);
+        assert_eq!(c.axis, Axis::Z);
+        assert!(c.snapped);
+    }
+
+    #[test]
+    fn slider_handles_thicken_from_one_layer() {
+        let mut c = Cutter::new(100);
+        c.enter(50.0, 100);
+        assert_eq!(c.hit_handle((0.50, 0.93), 100.0), None);
+        let hn = c.half_norm(100.0);
+        let x_neg = SLIDER_X0 + (c.pos - hn) * (SLIDER_X1 - SLIDER_X0);
+        assert_eq!(c.hit_handle((x_neg, 0.93), 100.0), Some(Handle::Neg));
+        c.dragging = Some(Handle::Pos);
+        let x_wide = SLIDER_X0 + (c.pos + 0.10) * (SLIDER_X1 - SLIDER_X0);
+        c.drag_handle((x_wide, 0.93), 100.0);
+        assert!((c.half_vox - 10.0).abs() < 0.6);
+        assert!(c.thickness_voxels() > 8.0);
+    }
+
+    #[test]
+    fn present_vec_idle_is_mode_zero() {
+        let c = Cutter::new(32);
+        assert_eq!(c.present_vec()[3], 0.0);
+        let mut c = c;
+        c.enter(8.0, 32);
+        assert!((c.present_vec()[3] - 1.0).abs() < 1e-5);
+        c.snapped = true;
+        assert!((c.present_vec()[3] - 1.5).abs() < 1e-5);
+        c.mode = CaptureMode::RichBox;
+        assert!((c.present_vec()[3] - 2.5).abs() < 1e-5);
+    }
+
+    #[test]
+    fn thickness_never_drops_below_one_layer() {
+        let mut c = Cutter::new(40);
+        c.nudge_half(-8.0, 40.0);
+        assert!((c.half_vox - 0.5).abs() < 1e-5);
+    }
+
+    #[test]
+    fn heightmap_flag_turns_on_when_axis_cycled() {
+        let mut c = Cutter::new(16);
+        assert!(!c.export_heightmap);
+        c.cycle_heightmap_axis();
+        assert!(c.export_heightmap);
+        assert_eq!(c.heightmap_axis, Axis::X);
+    }
+}

--- a/pycelium-win/src/export.rs
+++ b/pycelium-win/src/export.rs
@@ -6,7 +6,6 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
-use image::{GrayImage, ImageBuffer, Rgba, RgbaImage};
 use serde::Serialize;
 
 use crate::cutter::{Axis, CaptureMode, Cutter};
@@ -54,9 +53,7 @@ pub struct SlicePlane {
     pub hi: i32,
     pub biomass: Vec<f32>,
     pub soluble: Vec<f32>,
-    /// Depth of the strongest sample along the cutter axis, in voxels.
-    pub peak_depth: Vec<f32>,
-    /// Coordinate of that sample along the heightmap axis, normalized 0..1.
+    /// Coordinate of the strongest sample along the heightmap axis, normalized 0..1.
     pub height_along: Vec<f32>,
     pub volume_samples: Vec<OccupiedSample>,
 }
@@ -133,16 +130,14 @@ pub fn extract_slice(
     let height = v_axis.size(vol.width, vol.height, vol.depth);
     let axis_n = axis.size(vol.width, vol.height, vol.depth) as f32;
     let center = cutter.pos * axis_n;
-    let half = cutter.half_vox.max(0.5);
-    let lo = (center - half).floor() as i32;
-    let hi = (center + half).ceil() as i32;
-    let lo = lo.max(0);
-    let hi = hi.min(axis_n as i32 - 1).max(lo);
+    let n_layers = cutter.thickness_voxels().round().max(1.0) as i32;
+    let mid = center.round() as i32;
+    let lo = (mid - (n_layers - 1) / 2).max(0);
+    let hi = (lo + n_layers - 1).min(axis_n as i32 - 1).max(lo);
 
     let n = (width as usize).saturating_mul(height as usize);
     let mut biomass = vec![0.0f32; n];
     let mut soluble = vec![0.0f32; n];
-    let mut peak_depth = vec![center; n];
     let mut height_along = vec![0.0f32; n];
     let mut volume_samples = Vec::new();
     let keep_volume = include_volume || cutter.mode == CaptureMode::RichBox;
@@ -153,7 +148,6 @@ pub fn extract_slice(
             let i = (v * width + u) as usize;
             let mut best = 0.0f32;
             let mut best_sol = 0.0f32;
-            let mut best_t = center;
             let mut best_h = 0.0f32;
             for t in lo..=hi {
                 let (x, y, z) = voxel_at(axis, u, v, t);
@@ -169,7 +163,6 @@ pub fn extract_slice(
                 if b >= best {
                     best = b;
                     best_sol = s;
-                    best_t = t as f32;
                     let p = [
                         x as f32 / vol.width.max(1) as f32,
                         y as f32 / vol.height.max(1) as f32,
@@ -184,7 +177,6 @@ pub fn extract_slice(
             }
             biomass[i] = best;
             soluble[i] = best_sol;
-            peak_depth[i] = best_t;
             height_along[i] = best_h;
         }
     }
@@ -200,7 +192,6 @@ pub fn extract_slice(
         hi,
         biomass,
         soluble,
-        peak_depth,
         height_along,
         volume_samples,
     }
@@ -298,7 +289,7 @@ fn civil_from_unix(secs: u64) -> (i32, u32, u32, u32, u32, u32) {
     let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
     let mp = (5 * doy + 2) / 153;
     let d = doy - (153 * mp + 2) / 5 + 1;
-    let m = mp + if mp < 10 { 3 } else { -9 };
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
     let y = y + if m <= 2 { 1 } else { 0 };
     let rem = secs % 86400;
     (
@@ -312,49 +303,66 @@ fn civil_from_unix(secs: u64) -> (i32, u32, u32, u32, u32, u32) {
 }
 
 fn write_density_png(path: &Path, plane: &SlicePlane) -> Result<()> {
-    let mut img: RgbaImage = ImageBuffer::new(plane.width, plane.height);
+    let mut rgba = vec![0u8; (plane.width * plane.height * 4) as usize];
     for v in 0..plane.height {
         for u in 0..plane.width {
             let i = (v * plane.width + u) as usize;
             let hy = 1.0 - (-plane.biomass[i] * 3.0).exp();
             let food = 1.0 - (-plane.soluble[i] * 3.2).exp();
-            let r = ((0.04 + 0.58 * hy + 0.70 * food) * 255.0).clamp(0.0, 255.0) as u8;
-            let g = ((0.045 + 0.90 * hy + 0.28 * food) * 255.0).clamp(0.0, 255.0) as u8;
-            let b = ((0.05 + 0.80 * hy + 0.06 * food) * 255.0).clamp(0.0, 255.0) as u8;
-            img.put_pixel(u, v, Rgba([r, g, b, 255]));
+            let o = i * 4;
+            rgba[o] = ((0.04 + 0.58 * hy + 0.70 * food) * 255.0).clamp(0.0, 255.0) as u8;
+            rgba[o + 1] = ((0.045 + 0.90 * hy + 0.28 * food) * 255.0).clamp(0.0, 255.0) as u8;
+            rgba[o + 2] = ((0.05 + 0.80 * hy + 0.06 * food) * 255.0).clamp(0.0, 255.0) as u8;
+            rgba[o + 3] = 255;
         }
     }
-    img.save(path).with_context(|| format!("write {}", path.display()))
+    write_png(path, plane.width, plane.height, png::ColorType::Rgba, &rgba)
 }
 
 fn write_mask_png(path: &Path, plane: &SlicePlane) -> Result<()> {
     let max_b = plane.biomass.iter().copied().fold(0.0f32, f32::max).max(1e-6);
-    let mut img = GrayImage::new(plane.width, plane.height);
-    for v in 0..plane.height {
-        for u in 0..plane.width {
-            let i = (v * plane.width + u) as usize;
-            let q = ((plane.biomass[i] / max_b) * 255.0).clamp(0.0, 255.0) as u8;
-            img.put_pixel(u, v, image::Luma([q]));
-        }
+    let mut gray = vec![0u8; (plane.width * plane.height) as usize];
+    for (i, &b) in plane.biomass.iter().enumerate() {
+        gray[i] = ((b / max_b) * 255.0).clamp(0.0, 255.0) as u8;
     }
-    img.save(path).with_context(|| format!("write {}", path.display()))
+    write_png(path, plane.width, plane.height, png::ColorType::Grayscale, &gray)
 }
 
 fn write_height_png(path: &Path, plane: &SlicePlane) -> Result<()> {
     let stats = plane_stats(plane);
-    let mut img = GrayImage::new(plane.width, plane.height);
-    for v in 0..plane.height {
-        for u in 0..plane.width {
-            let i = (v * plane.width + u) as usize;
-            let q = if plane.biomass[i] > stats.threshold {
-                (plane.height_along[i] * 255.0).clamp(0.0, 255.0) as u8
-            } else {
-                0
-            };
-            img.put_pixel(u, v, image::Luma([q]));
-        }
+    let mut gray = vec![0u8; (plane.width * plane.height) as usize];
+    for (i, &b) in plane.biomass.iter().enumerate() {
+        gray[i] = if b > stats.threshold {
+            (plane.height_along[i] * 255.0).clamp(0.0, 255.0) as u8
+        } else {
+            0
+        };
     }
-    img.save(path).with_context(|| format!("write {}", path.display()))
+    write_png(path, plane.width, plane.height, png::ColorType::Grayscale, &gray)
+}
+
+fn write_png(
+    path: &Path,
+    width: u32,
+    height: u32,
+    color: png::ColorType,
+    data: &[u8],
+) -> Result<()> {
+    let file = fs::File::create(path).with_context(|| format!("write {}", path.display()))?;
+    let mut encoder = png::Encoder::new(file, width, height);
+    encoder.set_color(color);
+    encoder.set_depth(png::BitDepth::Eight);
+    let mut writer = encoder.write_header().context("png header")?;
+    writer.write_image_data(data).context("png pixels")?;
+    Ok(())
+}
+
+fn png_size(path: &Path) -> Result<(u32, u32)> {
+    let file = fs::File::open(path).with_context(|| format!("open {}", path.display()))?;
+    let decoder = png::Decoder::new(file);
+    let reader = decoder.read_info().context("png info")?;
+    let info = reader.info();
+    Ok((info.width, info.height))
 }
 
 fn write_json(
@@ -538,6 +546,7 @@ mod tests {
         let plane = extract_slice(&vol, &c, false);
         assert_eq!(plane.width, 8);
         assert_eq!(plane.height, 8);
+        assert_eq!(plane.axis, Axis::Z);
         assert_eq!(plane.u_axis, Axis::X);
         assert_eq!(plane.v_axis, Axis::Y);
         let i = (4 * 8 + 3) as usize;
@@ -637,9 +646,8 @@ mod tests {
         assert!(json.contains("\"axis\": \"z\""));
         let svg = fs::read_to_string(&paths.svg).unwrap();
         assert!(svg.contains("<svg"));
-        let img = image::open(&paths.png).unwrap();
-        assert_eq!(img.width(), 8);
-        assert_eq!(img.height(), 8);
+        let (pw, ph) = png_size(&paths.png).unwrap();
+        assert_eq!((pw, ph), (8, 8));
         let _ = fs::remove_dir_all(&dir);
     }
 

--- a/pycelium-win/src/export.rs
+++ b/pycelium-win/src/export.rs
@@ -1,0 +1,664 @@
+//! Slice bake: PNG density view, optional heightmap, density mask, SVG contours, JSON meta.
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use image::{GrayImage, ImageBuffer, Rgba, RgbaImage};
+use serde::Serialize;
+
+use crate::cutter::{Axis, CaptureMode, Cutter};
+
+#[derive(Clone, Debug)]
+pub struct VolumeFields {
+    pub width: u32,
+    pub height: u32,
+    pub depth: u32,
+    pub biomass: Vec<f32>,
+    pub soluble_c: Vec<f32>,
+}
+
+impl VolumeFields {
+    pub fn idx(&self, x: u32, y: u32, z: u32) -> usize {
+        let w = self.width as usize;
+        let h = self.height as usize;
+        (z as usize * h + y as usize) * w + x as usize
+    }
+
+    pub fn sample(&self, x: i32, y: i32, z: i32) -> (f32, f32) {
+        let w = self.width as i32;
+        let h = self.height as i32;
+        let d = self.depth as i32;
+        if w <= 0 || h <= 0 || d <= 0 {
+            return (0.0, 0.0);
+        }
+        let x = ((x % w) + w) % w;
+        let y = ((y % h) + h) % h;
+        let z = z.clamp(0, d - 1);
+        let i = self.idx(x as u32, y as u32, z as u32);
+        (self.biomass[i], self.soluble_c[i])
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SlicePlane {
+    pub axis: Axis,
+    pub u_axis: Axis,
+    pub v_axis: Axis,
+    pub width: u32,
+    pub height: u32,
+    pub center: f32,
+    pub lo: i32,
+    pub hi: i32,
+    pub biomass: Vec<f32>,
+    pub soluble: Vec<f32>,
+    /// Depth of the strongest sample along the cutter axis, in voxels.
+    pub peak_depth: Vec<f32>,
+    /// Coordinate of that sample along the heightmap axis, normalized 0..1.
+    pub height_along: Vec<f32>,
+    pub volume_samples: Vec<OccupiedSample>,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+pub struct OccupiedSample {
+    pub u: u32,
+    pub v: u32,
+    pub t: i32,
+    pub d: f32,
+}
+
+#[derive(Serialize)]
+struct SliceJson {
+    format: &'static str,
+    timestamp: String,
+    mode: &'static str,
+    axis: &'static str,
+    center_voxel: f32,
+    thickness_voxels: f32,
+    lo_voxel: i32,
+    hi_voxel: i32,
+    grid: GridMeta,
+    plane: PlaneMeta,
+    heightmap_axis: &'static str,
+    heightmap: bool,
+    stats: SliceStats,
+    density_encoding: &'static str,
+    density_u8: Vec<u8>,
+    samples: Vec<OccupiedSample>,
+}
+
+#[derive(Serialize)]
+struct GridMeta {
+    width: u32,
+    height: u32,
+    depth: u32,
+}
+
+#[derive(Serialize)]
+struct PlaneMeta {
+    u: &'static str,
+    v: &'static str,
+    width: u32,
+    height: u32,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct SliceStats {
+    pub min: f32,
+    pub max: f32,
+    pub mean: f32,
+    pub occupied: u32,
+    pub threshold: f32,
+}
+
+#[derive(Clone, Debug)]
+pub struct ExportPaths {
+    pub png: PathBuf,
+    pub json: PathBuf,
+    pub svg: PathBuf,
+    pub mask: PathBuf,
+    pub height: Option<PathBuf>,
+}
+
+pub fn extract_slice(
+    vol: &VolumeFields,
+    cutter: &Cutter,
+    include_volume: bool,
+) -> SlicePlane {
+    let axis = cutter.axis;
+    let (u_axis, v_axis) = axis.plane_uv();
+    let width = u_axis.size(vol.width, vol.height, vol.depth);
+    let height = v_axis.size(vol.width, vol.height, vol.depth);
+    let axis_n = axis.size(vol.width, vol.height, vol.depth) as f32;
+    let center = cutter.pos * axis_n;
+    let half = cutter.half_vox.max(0.5);
+    let lo = (center - half).floor() as i32;
+    let hi = (center + half).ceil() as i32;
+    let lo = lo.max(0);
+    let hi = hi.min(axis_n as i32 - 1).max(lo);
+
+    let n = (width as usize).saturating_mul(height as usize);
+    let mut biomass = vec![0.0f32; n];
+    let mut soluble = vec![0.0f32; n];
+    let mut peak_depth = vec![center; n];
+    let mut height_along = vec![0.0f32; n];
+    let mut volume_samples = Vec::new();
+    let keep_volume = include_volume || cutter.mode == CaptureMode::RichBox;
+    const MAX_SAMPLES: usize = 80_000;
+
+    for v in 0..height {
+        for u in 0..width {
+            let i = (v * width + u) as usize;
+            let mut best = 0.0f32;
+            let mut best_sol = 0.0f32;
+            let mut best_t = center;
+            let mut best_h = 0.0f32;
+            for t in lo..=hi {
+                let (x, y, z) = voxel_at(axis, u, v, t);
+                let (b, s) = vol.sample(x, y, z);
+                if keep_volume && b > 0.02 && volume_samples.len() < MAX_SAMPLES {
+                    volume_samples.push(OccupiedSample {
+                        u,
+                        v,
+                        t,
+                        d: (b * 1000.0).round() / 1000.0,
+                    });
+                }
+                if b >= best {
+                    best = b;
+                    best_sol = s;
+                    best_t = t as f32;
+                    let p = [
+                        x as f32 / vol.width.max(1) as f32,
+                        y as f32 / vol.height.max(1) as f32,
+                        z as f32 / vol.depth.max(1) as f32,
+                    ];
+                    best_h = match cutter.heightmap_axis {
+                        Axis::X => p[0],
+                        Axis::Y => p[1],
+                        Axis::Z => p[2],
+                    };
+                }
+            }
+            biomass[i] = best;
+            soluble[i] = best_sol;
+            peak_depth[i] = best_t;
+            height_along[i] = best_h;
+        }
+    }
+
+    SlicePlane {
+        axis,
+        u_axis,
+        v_axis,
+        width,
+        height,
+        center,
+        lo,
+        hi,
+        biomass,
+        soluble,
+        peak_depth,
+        height_along,
+        volume_samples,
+    }
+}
+
+fn voxel_at(axis: Axis, u: u32, v: u32, t: i32) -> (i32, i32, i32) {
+    match axis {
+        Axis::X => (t, u as i32, v as i32),
+        Axis::Y => (u as i32, t, v as i32),
+        Axis::Z => (u as i32, v as i32, t),
+    }
+}
+
+pub fn plane_stats(plane: &SlicePlane) -> SliceStats {
+    let mut min = f32::INFINITY;
+    let mut max = 0.0f32;
+    let mut sum = 0.0f32;
+    let mut occupied = 0u32;
+    for &b in &plane.biomass {
+        min = min.min(b);
+        max = max.max(b);
+        sum += b;
+        if b > 0.02 {
+            occupied += 1;
+        }
+    }
+    if plane.biomass.is_empty() {
+        min = 0.0;
+    }
+    let n = plane.biomass.len().max(1) as f32;
+    let threshold = (max * 0.15).max(0.02);
+    SliceStats {
+        min,
+        max,
+        mean: sum / n,
+        occupied,
+        threshold,
+    }
+}
+
+pub fn write_exports(
+    dir: &Path,
+    plane: &SlicePlane,
+    cutter: &Cutter,
+    grid: (u32, u32, u32),
+    stamp: &str,
+) -> Result<ExportPaths> {
+    fs::create_dir_all(dir).with_context(|| format!("create {}", dir.display()))?;
+    let stem = format!(
+        "pycelium_{}_{}_{}",
+        stamp,
+        cutter.axis.as_str(),
+        cutter.mode.as_str()
+    );
+    let png = dir.join(format!("{stem}.png"));
+    let json = dir.join(format!("{stem}.json"));
+    let svg = dir.join(format!("{stem}.svg"));
+    let mask = dir.join(format!("{stem}_mask.png"));
+    let height = if cutter.export_heightmap {
+        Some(dir.join(format!("{stem}_height.png")))
+    } else {
+        None
+    };
+
+    write_density_png(&png, plane)?;
+    write_mask_png(&mask, plane)?;
+    if let Some(ref hpath) = height {
+        write_height_png(hpath, plane)?;
+    }
+    write_svg(&svg, plane)?;
+    write_json(&json, plane, cutter, grid, stamp)?;
+
+    Ok(ExportPaths {
+        png,
+        json,
+        svg,
+        mask,
+        height,
+    })
+}
+
+pub fn utc_stamp(now: SystemTime) -> String {
+    let secs = now.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+    let (y, m, d, hh, mm, ss) = civil_from_unix(secs);
+    format!("{y:04}{m:02}{d:02}_{hh:02}{mm:02}{ss:02}")
+}
+
+/// Howard Hinnant civil-from-days (UTC).
+fn civil_from_unix(secs: u64) -> (i32, u32, u32, u32, u32, u32) {
+    let z = (secs / 86400) as i64 + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = mp + if mp < 10 { 3 } else { -9 };
+    let y = y + if m <= 2 { 1 } else { 0 };
+    let rem = secs % 86400;
+    (
+        y as i32,
+        m as u32,
+        d as u32,
+        (rem / 3600) as u32,
+        ((rem % 3600) / 60) as u32,
+        (rem % 60) as u32,
+    )
+}
+
+fn write_density_png(path: &Path, plane: &SlicePlane) -> Result<()> {
+    let mut img: RgbaImage = ImageBuffer::new(plane.width, plane.height);
+    for v in 0..plane.height {
+        for u in 0..plane.width {
+            let i = (v * plane.width + u) as usize;
+            let hy = 1.0 - (-plane.biomass[i] * 3.0).exp();
+            let food = 1.0 - (-plane.soluble[i] * 3.2).exp();
+            let r = ((0.04 + 0.58 * hy + 0.70 * food) * 255.0).clamp(0.0, 255.0) as u8;
+            let g = ((0.045 + 0.90 * hy + 0.28 * food) * 255.0).clamp(0.0, 255.0) as u8;
+            let b = ((0.05 + 0.80 * hy + 0.06 * food) * 255.0).clamp(0.0, 255.0) as u8;
+            img.put_pixel(u, v, Rgba([r, g, b, 255]));
+        }
+    }
+    img.save(path).with_context(|| format!("write {}", path.display()))
+}
+
+fn write_mask_png(path: &Path, plane: &SlicePlane) -> Result<()> {
+    let max_b = plane.biomass.iter().copied().fold(0.0f32, f32::max).max(1e-6);
+    let mut img = GrayImage::new(plane.width, plane.height);
+    for v in 0..plane.height {
+        for u in 0..plane.width {
+            let i = (v * plane.width + u) as usize;
+            let q = ((plane.biomass[i] / max_b) * 255.0).clamp(0.0, 255.0) as u8;
+            img.put_pixel(u, v, image::Luma([q]));
+        }
+    }
+    img.save(path).with_context(|| format!("write {}", path.display()))
+}
+
+fn write_height_png(path: &Path, plane: &SlicePlane) -> Result<()> {
+    let stats = plane_stats(plane);
+    let mut img = GrayImage::new(plane.width, plane.height);
+    for v in 0..plane.height {
+        for u in 0..plane.width {
+            let i = (v * plane.width + u) as usize;
+            let q = if plane.biomass[i] > stats.threshold {
+                (plane.height_along[i] * 255.0).clamp(0.0, 255.0) as u8
+            } else {
+                0
+            };
+            img.put_pixel(u, v, image::Luma([q]));
+        }
+    }
+    img.save(path).with_context(|| format!("write {}", path.display()))
+}
+
+fn write_json(
+    path: &Path,
+    plane: &SlicePlane,
+    cutter: &Cutter,
+    grid: (u32, u32, u32),
+    stamp: &str,
+) -> Result<()> {
+    let stats = plane_stats(plane);
+    let max_b = stats.max.max(1e-6);
+    let density_u8 = plane
+        .biomass
+        .iter()
+        .map(|b| ((b / max_b) * 255.0).clamp(0.0, 255.0) as u8)
+        .collect();
+    let samples = if cutter.mode == CaptureMode::RichBox {
+        plane.volume_samples.clone()
+    } else {
+        Vec::new()
+    };
+    let doc = SliceJson {
+        format: "pycelium-slice-v1",
+        timestamp: stamp.to_string(),
+        mode: cutter.mode.as_str(),
+        axis: cutter.axis.as_str(),
+        center_voxel: plane.center,
+        thickness_voxels: cutter.thickness_voxels(),
+        lo_voxel: plane.lo,
+        hi_voxel: plane.hi,
+        grid: GridMeta {
+            width: grid.0,
+            height: grid.1,
+            depth: grid.2,
+        },
+        plane: PlaneMeta {
+            u: plane.u_axis.as_str(),
+            v: plane.v_axis.as_str(),
+            width: plane.width,
+            height: plane.height,
+        },
+        heightmap_axis: cutter.heightmap_axis.as_str(),
+        heightmap: cutter.export_heightmap,
+        stats,
+        density_encoding: "u8_row_major",
+        density_u8,
+        samples,
+    };
+    let text = serde_json::to_string_pretty(&doc).context("json")?;
+    fs::write(path, text).with_context(|| format!("write {}", path.display()))
+}
+
+fn write_svg(path: &Path, plane: &SlicePlane) -> Result<()> {
+    let stats = plane_stats(plane);
+    let lines = marching_segments(
+        plane.width,
+        plane.height,
+        &plane.biomass,
+        stats.threshold,
+    );
+    let mut out = String::new();
+    out.push_str(&format!(
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 {} {}\" width=\"{}\" height=\"{}\" fill=\"none\">\n",
+        plane.width, plane.height, plane.width, plane.height
+    ));
+    out.push_str("  <rect width=\"100%\" height=\"100%\" fill=\"#0a0c0d\"/>\n");
+    for (a, b) in lines {
+        out.push_str(&format!(
+            "  <line x1=\"{:.2}\" y1=\"{:.2}\" x2=\"{:.2}\" y2=\"{:.2}\" stroke=\"#9ef0d8\" stroke-width=\"0.8\"/>\n",
+            a.0, a.1, b.0, b.1
+        ));
+    }
+    out.push_str("</svg>\n");
+    let mut f = fs::File::create(path).with_context(|| format!("write {}", path.display()))?;
+    f.write_all(out.as_bytes())?;
+    Ok(())
+}
+
+/// Marching-squares line segments at `threshold` on a row-major field.
+pub fn marching_segments(
+    w: u32,
+    h: u32,
+    field: &[f32],
+    threshold: f32,
+) -> Vec<((f32, f32), (f32, f32))> {
+    let mut lines = Vec::new();
+    if w < 2 || h < 2 {
+        return lines;
+    }
+    let at = |x: u32, y: u32| field[(y * w + x) as usize];
+    for y in 0..h - 1 {
+        for x in 0..w - 1 {
+            let v0 = at(x, y);
+            let v1 = at(x + 1, y);
+            let v2 = at(x + 1, y + 1);
+            let v3 = at(x, y + 1);
+            let mut code = 0u8;
+            if v0 >= threshold {
+                code |= 1;
+            }
+            if v1 >= threshold {
+                code |= 2;
+            }
+            if v2 >= threshold {
+                code |= 4;
+            }
+            if v3 >= threshold {
+                code |= 8;
+            }
+            if code == 0 || code == 15 {
+                continue;
+            }
+            let fx = x as f32;
+            let fy = y as f32;
+            let lerp = |a: f32, b: f32| {
+                let d = b - a;
+                if d.abs() < 1e-6 {
+                    0.5
+                } else {
+                    ((threshold - a) / d).clamp(0.0, 1.0)
+                }
+            };
+            let top = (fx + lerp(v0, v1), fy);
+            let right = (fx + 1.0, fy + lerp(v1, v2));
+            let bottom = (fx + lerp(v3, v2), fy + 1.0);
+            let left = (fx, fy + lerp(v0, v3));
+            let pair = match code {
+                1 | 14 => Some((left, top)),
+                2 | 13 => Some((top, right)),
+                3 | 12 => Some((left, right)),
+                4 | 11 => Some((right, bottom)),
+                6 | 9 => Some((top, bottom)),
+                7 | 8 => Some((left, bottom)),
+                5 => {
+                    lines.push((left, top));
+                    lines.push((right, bottom));
+                    None
+                }
+                10 => {
+                    lines.push((top, right));
+                    lines.push((left, bottom));
+                    None
+                }
+                _ => None,
+            };
+            if let Some(seg) = pair {
+                lines.push(seg);
+            }
+        }
+    }
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cutter::Cutter;
+
+    fn brick(w: u32, h: u32, d: u32, mark: (u32, u32, u32), val: f32) -> VolumeFields {
+        let n = (w * h * d) as usize;
+        let mut vol = VolumeFields {
+            width: w,
+            height: h,
+            depth: d,
+            biomass: vec![0.0f32; n],
+            soluble_c: vec![0.0f32; n],
+        };
+        let i = vol.idx(mark.0, mark.1, mark.2);
+        vol.biomass[i] = val;
+        vol
+    }
+
+    #[test]
+    fn z_squash_finds_marked_voxel() {
+        let vol = brick(8, 8, 8, (3, 4, 5), 1.5);
+        let mut c = Cutter::new(8);
+        c.enter(5.0, 8);
+        c.axis = Axis::Z;
+        c.pos = 5.0 / 8.0;
+        c.half_vox = 0.5;
+        let plane = extract_slice(&vol, &c, false);
+        assert_eq!(plane.width, 8);
+        assert_eq!(plane.height, 8);
+        assert_eq!(plane.u_axis, Axis::X);
+        assert_eq!(plane.v_axis, Axis::Y);
+        let i = (4 * 8 + 3) as usize;
+        assert!((plane.biomass[i] - 1.5).abs() < 1e-5);
+        assert!(plane.biomass.iter().filter(|b| **b > 0.0).count() == 1);
+    }
+
+    #[test]
+    fn x_axis_vertical_slice_maps_yz() {
+        let vol = brick(8, 6, 4, (2, 1, 3), 0.8);
+        let mut c = Cutter::new(4);
+        c.enter(2.0, 4);
+        c.axis = Axis::X;
+        c.pos = 2.0 / 8.0;
+        c.half_vox = 0.5;
+        let plane = extract_slice(&vol, &c, false);
+        assert_eq!(plane.width, 6);
+        assert_eq!(plane.height, 4);
+        let i = (3 * 6 + 1) as usize;
+        assert!((plane.biomass[i] - 0.8).abs() < 1e-5);
+    }
+
+    #[test]
+    fn squash_thickens_across_nearby_layers() {
+        let mut vol = brick(4, 4, 8, (1, 1, 2), 0.4);
+        let i = vol.idx(1, 1, 4);
+        vol.biomass[i] = 1.2;
+        let mut c = Cutter::new(8);
+        c.enter(3.0, 8);
+        c.pos = 3.0 / 8.0;
+        c.half_vox = 0.5;
+        let thin = extract_slice(&vol, &c, false);
+        c.half_vox = 2.0;
+        let thick = extract_slice(&vol, &c, false);
+        let p = (1 * 4 + 1) as usize;
+        assert!(thin.biomass[p] < 0.01);
+        assert!((thick.biomass[p] - 1.2).abs() < 1e-5);
+    }
+
+    #[test]
+    fn rich_mode_keeps_occupied_volume_samples() {
+        let vol = brick(4, 4, 4, (1, 2, 2), 0.5);
+        let mut c = Cutter::new(4);
+        c.enter(2.0, 4);
+        c.mode = CaptureMode::RichBox;
+        c.pos = 0.5;
+        c.half_vox = 1.0;
+        let plane = extract_slice(&vol, &c, true);
+        assert!(plane.volume_samples.iter().any(|s| s.u == 1 && s.v == 2));
+    }
+
+    #[test]
+    fn heightmap_follows_chosen_axis() {
+        let vol = brick(4, 4, 8, (1, 1, 6), 1.0);
+        let mut c = Cutter::new(8);
+        c.enter(6.0, 8);
+        c.pos = 6.0 / 8.0;
+        c.export_heightmap = true;
+        c.heightmap_axis = Axis::Z;
+        let plane = extract_slice(&vol, &c, false);
+        let i = (1 * 4 + 1) as usize;
+        assert!((plane.height_along[i] - 6.0 / 8.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn marching_squares_boxes_a_block() {
+        let mut field = vec![0.0f32; 16];
+        field[5] = 1.0;
+        field[6] = 1.0;
+        field[9] = 1.0;
+        field[10] = 1.0;
+        let segs = marching_segments(4, 4, &field, 0.5);
+        assert!(segs.len() >= 4);
+    }
+
+    #[test]
+    fn write_bundle_creates_png_json_svg_mask() {
+        let dir = std::env::temp_dir().join(format!(
+            "pycelium-slice-test-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        let vol = brick(8, 8, 4, (2, 3, 1), 1.0);
+        let mut c = Cutter::new(4);
+        c.enter(1.0, 4);
+        c.pos = 0.25;
+        c.export_heightmap = true;
+        let plane = extract_slice(&vol, &c, false);
+        let paths = write_exports(&dir, &plane, &c, (8, 8, 4), "20260102_030405").unwrap();
+        assert!(paths.png.exists());
+        assert!(paths.json.exists());
+        assert!(paths.svg.exists());
+        assert!(paths.mask.exists());
+        assert!(paths.height.unwrap().exists());
+        let json = fs::read_to_string(&paths.json).unwrap();
+        assert!(json.contains("pycelium-slice-v1"));
+        assert!(json.contains("\"axis\": \"z\""));
+        let svg = fs::read_to_string(&paths.svg).unwrap();
+        assert!(svg.contains("<svg"));
+        let img = image::open(&paths.png).unwrap();
+        assert_eq!(img.width(), 8);
+        assert_eq!(img.height(), 8);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn utc_stamp_is_compact() {
+        let t = UNIX_EPOCH + std::time::Duration::from_secs(1_704_067_200); // 2024-01-01 00:00:00 UTC
+        let s = utc_stamp(t);
+        assert_eq!(s, "20240101_000000");
+    }
+
+    #[test]
+    fn stats_count_occupied() {
+        let vol = brick(4, 4, 4, (0, 0, 0), 0.3);
+        let mut c = Cutter::new(4);
+        c.enter(0.0, 4);
+        c.pos = 0.0;
+        let plane = extract_slice(&vol, &c, false);
+        let s = plane_stats(&plane);
+        assert_eq!(s.occupied, 1);
+        assert!(s.max >= 0.3);
+    }
+}

--- a/pycelium-win/src/gpu.rs
+++ b/pycelium-win/src/gpu.rs
@@ -607,8 +607,8 @@ fn read_f32_buffer(
         .poll(wgpu::PollType::wait_indefinitely())
         .context("poll slice readback")?;
     rx.recv().context("readback callback")??;
-    let data = slice.get_mapped_range();
-    let floats = bytemuck::cast_slice(&data).to_vec();
+    let data = slice.get_mapped_range().context("map slice range")?;
+    let floats = bytemuck::cast_slice(data.as_ref()).to_vec();
     drop(data);
     staging.unmap();
     Ok(floats)

--- a/pycelium-win/src/gpu.rs
+++ b/pycelium-win/src/gpu.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use wgpu::util::DeviceExt;
 
 use crate::config::MemoryPlan;
+use crate::export::VolumeFields;
 use crate::memory::HostWorld;
 use crate::types::{PresentUniforms, SimUniforms, SliceView, TEL_COUNT, Tip};
 
@@ -134,7 +135,9 @@ impl MyceliumGpu {
             device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
                 label: Some(name),
                 contents: bytemuck::cast_slice(data),
-                usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+                usage: wgpu::BufferUsages::STORAGE
+                    | wgpu::BufferUsages::COPY_DST
+                    | wgpu::BufferUsages::COPY_SRC,
             })
         };
         let zeros = vec![0f32; cells as usize];
@@ -391,6 +394,7 @@ impl MyceliumGpu {
         label_density: f32,
         label_fade: f32,
         has_picked: bool,
+        cutter: [f32; 4],
     ) {
         let present = PresentUniforms {
             width: self.width,
@@ -424,6 +428,7 @@ impl MyceliumGpu {
             slice_ox: self.slice.ox,
             slice_oy: self.slice.oy,
             hud_ui: [cursor[0], cursor[1], label_density, label_fade],
+            cutter,
         };
         queue.write_buffer(&self.present_buf, 0, bytemuck::bytes_of(&present));
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
@@ -456,6 +461,25 @@ impl MyceliumGpu {
             pass.draw(0..3, 0..1);
         }
         queue.submit(Some(encoder.finish()));
+    }
+
+    /// Copy biomass + soluble C back to the host for a slice bake.
+    pub fn read_volume_fields(
+        &self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+    ) -> Result<VolumeFields> {
+        let cells = (self.width * self.height * self.depth) as u64;
+        let bytes = cells * 4;
+        let biomass = read_f32_buffer(device, queue, &self.biomass, bytes)?;
+        let soluble_c = read_f32_buffer(device, queue, &self.soluble_c, bytes)?;
+        Ok(VolumeFields {
+            width: self.width,
+            height: self.height,
+            depth: self.depth,
+            biomass,
+            soluble_c,
+        })
     }
 
     fn clear_telemetry(&self, queue: &wgpu::Queue) {
@@ -555,6 +579,39 @@ mod shader_tests {
             .validate(&module)
             .expect("present.wgsl should validate");
     }
+}
+
+fn read_f32_buffer(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    src: &wgpu::Buffer,
+    bytes: u64,
+) -> Result<Vec<f32>> {
+    let staging = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("slice-readback"),
+        size: bytes,
+        usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("slice-readback"),
+    });
+    encoder.copy_buffer_to_buffer(src, 0, &staging, 0, bytes);
+    queue.submit(Some(encoder.finish()));
+    let slice = staging.slice(..);
+    let (tx, rx) = std::sync::mpsc::channel();
+    slice.map_async(wgpu::MapMode::Read, move |result| {
+        let _ = tx.send(result);
+    });
+    device
+        .poll(wgpu::PollType::wait_indefinitely())
+        .context("poll slice readback")?;
+    rx.recv().context("readback callback")??;
+    let data = slice.get_mapped_range();
+    let floats = bytemuck::cast_slice(&data).to_vec();
+    drop(data);
+    staging.unmap();
+    Ok(floats)
 }
 
 fn bind(buffer: &wgpu::Buffer, binding: u32) -> wgpu::BindGroupEntry<'_> {

--- a/pycelium-win/src/gpu.rs
+++ b/pycelium-win/src/gpu.rs
@@ -3,6 +3,7 @@ use wgpu::util::DeviceExt;
 
 use crate::config::MemoryPlan;
 use crate::export::VolumeFields;
+use crate::hud_font;
 use crate::memory::HostWorld;
 use crate::types::{PresentUniforms, SimUniforms, SliceView, TEL_COUNT, Tip};
 
@@ -92,6 +93,10 @@ pub struct MyceliumGpu {
     sim_bg: wgpu::BindGroup,
     present_pipeline: wgpu::RenderPipeline,
     present_bg: wgpu::BindGroup,
+    #[allow(dead_code)]
+    font_tex: wgpu::Texture,
+    #[allow(dead_code)]
+    font_samp: wgpu::Sampler,
     tick: u32,
     last_pick: u32,
 }
@@ -186,7 +191,51 @@ impl MyceliumGpu {
                 storage_entry(5, wgpu::ShaderStages::FRAGMENT, true),
                 storage_entry(6, wgpu::ShaderStages::FRAGMENT, true),
                 storage_entry(7, wgpu::ShaderStages::FRAGMENT, true),
+                wgpu::BindGroupLayoutEntry {
+                    binding: 8,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 9,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
             ],
+        });
+
+        let atlas = hud_font::rasterize_atlas();
+        let font_tex = device.create_texture_with_data(
+            queue,
+            &wgpu::TextureDescriptor {
+                label: Some("hud-font"),
+                size: wgpu::Extent3d {
+                    width: atlas.width,
+                    height: atlas.height,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: wgpu::TextureFormat::R8Unorm,
+                usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+                view_formats: &[],
+            },
+            wgpu::util::TextureDataOrder::LayerMajor,
+            &atlas.pixels,
+        );
+        let font_view = font_tex.create_view(&wgpu::TextureViewDescriptor::default());
+        let font_samp = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("hud-font-samp"),
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            ..Default::default()
         });
 
         let sim_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
@@ -272,6 +321,14 @@ impl MyceliumGpu {
                 bind(&organic, 5),
                 bind(&tel, 6),
                 bind(&tip_buf, 7),
+                wgpu::BindGroupEntry {
+                    binding: 8,
+                    resource: wgpu::BindingResource::TextureView(&font_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 9,
+                    resource: wgpu::BindingResource::Sampler(&font_samp),
+                },
             ],
         });
 
@@ -308,6 +365,8 @@ impl MyceliumGpu {
             sim_bg,
             present_pipeline,
             present_bg,
+            font_tex,
+            font_samp,
             tick: 0,
             last_pick: 0,
         })

--- a/pycelium-win/src/hud_font.rs
+++ b/pycelium-win/src/hud_font.rs
@@ -1,0 +1,353 @@
+//! Geometric grotesque HUD captions — stroked, y=0 at the top (not a 5×5 bitmap).
+//!
+//! The previous 5×5 pack was sampled with a Y flip (`1.0 - cell.y`) while bits were
+//! documented as top-left, so letters read inverted / noisy. This atlas is built
+//! upright and sampled with cell.y = 0 at the top.
+
+pub const GLYPH: u32 = 32;
+pub const ATLAS_COLS: u32 = 16;
+pub const ATLAS_ROWS: u32 = 3;
+
+type Pt = (f32, f32);
+type Seg = (Pt, Pt);
+
+pub struct FontAtlas {
+    pub width: u32,
+    pub height: u32,
+    pub pixels: Vec<u8>,
+}
+
+/// 0 = space, 1–26 = A–Z, 27 = `:`.
+pub fn rasterize_atlas() -> FontAtlas {
+    let width = ATLAS_COLS * GLYPH;
+    let height = ATLAS_ROWS * GLYPH;
+    let mut pixels = vec![0u8; (width * height) as usize];
+    for ch in 0..=27 {
+        let col = (ch as u32) % ATLAS_COLS;
+        let row = (ch as u32) / ATLAS_COLS;
+        let glyph = raster_glyph(ch);
+        for y in 0..GLYPH {
+            for x in 0..GLYPH {
+                let dx = col * GLYPH + x;
+                let dy = row * GLYPH + y;
+                pixels[(dy * width + dx) as usize] = glyph[(y * GLYPH + x) as usize];
+            }
+        }
+    }
+    FontAtlas {
+        width,
+        height,
+        pixels,
+    }
+}
+
+pub fn raster_glyph(ch: i32) -> Vec<u8> {
+    let strokes = glyph_strokes(ch);
+    let thick = 0.078;
+    let mut out = vec![0u8; (GLYPH * GLYPH) as usize];
+    if strokes.is_empty() {
+        return out;
+    }
+    let n = GLYPH as f32;
+    for y in 0..GLYPH {
+        for x in 0..GLYPH {
+            let p = ((x as f32 + 0.5) / n, (y as f32 + 0.5) / n);
+            let mut d = 1.0e9_f32;
+            for &(a, b) in strokes {
+                d = d.min(sd_segment(p, a, b));
+            }
+            let fade = 1.35 / n;
+            let cover = (1.0 - (d - thick) / fade).clamp(0.0, 1.0);
+            out[(y * GLYPH + x) as usize] = (cover * 255.0) as u8;
+        }
+    }
+    out
+}
+
+fn sd_segment(p: Pt, a: Pt, b: Pt) -> f32 {
+    let pax = p.0 - a.0;
+    let pay = p.1 - a.1;
+    let bax = b.0 - a.0;
+    let bay = b.1 - a.1;
+    let denom = (bax * bax + bay * bay).max(1.0e-8);
+    let h = (pax * bax + pay * bay) / denom;
+    let h = h.clamp(0.0, 1.0);
+    let dx = pax - bax * h;
+    let dy = pay - bay * h;
+    (dx * dx + dy * dy).sqrt()
+}
+
+fn glyph_strokes(ch: i32) -> &'static [Seg] {
+    match ch {
+        1 => A,
+        2 => B,
+        3 => C,
+        4 => D,
+        5 => E,
+        6 => F,
+        7 => G,
+        8 => H,
+        9 => I,
+        10 => J,
+        11 => K,
+        12 => L,
+        13 => M,
+        14 => N,
+        15 => O,
+        16 => P,
+        17 => Q,
+        18 => R,
+        19 => S,
+        20 => T,
+        21 => U,
+        22 => V,
+        23 => W,
+        24 => X,
+        25 => Y,
+        26 => Z,
+        27 => COLON,
+        _ => &[],
+    }
+}
+
+// y = 0 at the top. Geometric grotesque (system-UI / Futura-ish).
+const A: &[Seg] = &[
+    ((0.18, 0.88), (0.50, 0.14)),
+    ((0.82, 0.88), (0.50, 0.14)),
+    ((0.30, 0.58), (0.70, 0.58)),
+];
+const B: &[Seg] = &[
+    ((0.22, 0.14), (0.22, 0.88)),
+    ((0.22, 0.14), (0.62, 0.14)),
+    ((0.62, 0.14), (0.76, 0.26)),
+    ((0.76, 0.26), (0.62, 0.42)),
+    ((0.62, 0.42), (0.22, 0.42)),
+    ((0.22, 0.42), (0.66, 0.42)),
+    ((0.66, 0.42), (0.80, 0.64)),
+    ((0.80, 0.64), (0.66, 0.88)),
+    ((0.66, 0.88), (0.22, 0.88)),
+];
+const C: &[Seg] = &[
+    ((0.76, 0.26), (0.60, 0.14)),
+    ((0.60, 0.14), (0.36, 0.14)),
+    ((0.36, 0.14), (0.20, 0.30)),
+    ((0.20, 0.30), (0.20, 0.72)),
+    ((0.20, 0.72), (0.36, 0.88)),
+    ((0.36, 0.88), (0.60, 0.88)),
+    ((0.60, 0.88), (0.76, 0.76)),
+];
+const D: &[Seg] = &[
+    ((0.22, 0.14), (0.22, 0.88)),
+    ((0.22, 0.14), (0.58, 0.14)),
+    ((0.58, 0.14), (0.80, 0.32)),
+    ((0.80, 0.32), (0.80, 0.70)),
+    ((0.80, 0.70), (0.58, 0.88)),
+    ((0.58, 0.88), (0.22, 0.88)),
+];
+const E: &[Seg] = &[
+    ((0.24, 0.14), (0.24, 0.88)),
+    ((0.24, 0.14), (0.78, 0.14)),
+    ((0.24, 0.50), (0.68, 0.50)),
+    ((0.24, 0.88), (0.78, 0.88)),
+];
+const F: &[Seg] = &[
+    ((0.24, 0.14), (0.24, 0.88)),
+    ((0.24, 0.14), (0.78, 0.14)),
+    ((0.24, 0.50), (0.66, 0.50)),
+];
+const G: &[Seg] = &[
+    ((0.76, 0.26), (0.60, 0.14)),
+    ((0.60, 0.14), (0.36, 0.14)),
+    ((0.36, 0.14), (0.20, 0.30)),
+    ((0.20, 0.30), (0.20, 0.72)),
+    ((0.20, 0.72), (0.36, 0.88)),
+    ((0.36, 0.88), (0.62, 0.88)),
+    ((0.62, 0.88), (0.78, 0.72)),
+    ((0.78, 0.72), (0.78, 0.56)),
+    ((0.78, 0.56), (0.52, 0.56)),
+];
+const H: &[Seg] = &[
+    ((0.22, 0.14), (0.22, 0.88)),
+    ((0.78, 0.14), (0.78, 0.88)),
+    ((0.22, 0.50), (0.78, 0.50)),
+];
+const I: &[Seg] = &[
+    ((0.28, 0.14), (0.72, 0.14)),
+    ((0.50, 0.14), (0.50, 0.88)),
+    ((0.28, 0.88), (0.72, 0.88)),
+];
+const J: &[Seg] = &[
+    ((0.30, 0.14), (0.78, 0.14)),
+    ((0.62, 0.14), (0.62, 0.74)),
+    ((0.62, 0.74), (0.48, 0.88)),
+    ((0.48, 0.88), (0.28, 0.88)),
+    ((0.28, 0.88), (0.20, 0.76)),
+];
+const K: &[Seg] = &[
+    ((0.22, 0.14), (0.22, 0.88)),
+    ((0.74, 0.14), (0.22, 0.52)),
+    ((0.22, 0.52), (0.76, 0.88)),
+];
+const L: &[Seg] = &[
+    ((0.24, 0.14), (0.24, 0.88)),
+    ((0.24, 0.88), (0.78, 0.88)),
+];
+const M: &[Seg] = &[
+    ((0.16, 0.88), (0.16, 0.14)),
+    ((0.16, 0.14), (0.50, 0.58)),
+    ((0.84, 0.14), (0.50, 0.58)),
+    ((0.84, 0.14), (0.84, 0.88)),
+];
+const N: &[Seg] = &[
+    ((0.22, 0.88), (0.22, 0.14)),
+    ((0.22, 0.14), (0.78, 0.88)),
+    ((0.78, 0.88), (0.78, 0.14)),
+];
+const O: &[Seg] = &[
+    ((0.36, 0.14), (0.64, 0.14)),
+    ((0.64, 0.14), (0.80, 0.30)),
+    ((0.80, 0.30), (0.80, 0.72)),
+    ((0.80, 0.72), (0.64, 0.88)),
+    ((0.64, 0.88), (0.36, 0.88)),
+    ((0.36, 0.88), (0.20, 0.72)),
+    ((0.20, 0.72), (0.20, 0.30)),
+    ((0.20, 0.30), (0.36, 0.14)),
+];
+const P: &[Seg] = &[
+    ((0.22, 0.14), (0.22, 0.88)),
+    ((0.22, 0.14), (0.64, 0.14)),
+    ((0.64, 0.14), (0.78, 0.28)),
+    ((0.78, 0.28), (0.64, 0.46)),
+    ((0.64, 0.46), (0.22, 0.46)),
+];
+const Q: &[Seg] = &[
+    ((0.36, 0.14), (0.64, 0.14)),
+    ((0.64, 0.14), (0.80, 0.30)),
+    ((0.80, 0.30), (0.80, 0.68)),
+    ((0.80, 0.68), (0.64, 0.84)),
+    ((0.64, 0.84), (0.36, 0.84)),
+    ((0.36, 0.84), (0.20, 0.68)),
+    ((0.20, 0.68), (0.20, 0.30)),
+    ((0.20, 0.30), (0.36, 0.14)),
+    ((0.52, 0.64), (0.80, 0.90)),
+];
+const R: &[Seg] = &[
+    ((0.22, 0.14), (0.22, 0.88)),
+    ((0.22, 0.14), (0.64, 0.14)),
+    ((0.64, 0.14), (0.78, 0.28)),
+    ((0.78, 0.28), (0.64, 0.46)),
+    ((0.64, 0.46), (0.22, 0.46)),
+    ((0.46, 0.46), (0.78, 0.88)),
+];
+const S: &[Seg] = &[
+    ((0.74, 0.24), (0.58, 0.14)),
+    ((0.58, 0.14), (0.34, 0.14)),
+    ((0.34, 0.14), (0.22, 0.26)),
+    ((0.22, 0.26), (0.34, 0.40)),
+    ((0.34, 0.40), (0.66, 0.54)),
+    ((0.66, 0.54), (0.78, 0.70)),
+    ((0.78, 0.70), (0.64, 0.88)),
+    ((0.64, 0.88), (0.34, 0.88)),
+    ((0.34, 0.88), (0.22, 0.76)),
+];
+const T: &[Seg] = &[
+    ((0.16, 0.14), (0.84, 0.14)),
+    ((0.50, 0.14), (0.50, 0.88)),
+];
+const U: &[Seg] = &[
+    ((0.22, 0.14), (0.22, 0.70)),
+    ((0.22, 0.70), (0.36, 0.88)),
+    ((0.36, 0.88), (0.64, 0.88)),
+    ((0.64, 0.88), (0.78, 0.70)),
+    ((0.78, 0.70), (0.78, 0.14)),
+];
+const V: &[Seg] = &[
+    ((0.16, 0.14), (0.50, 0.88)),
+    ((0.84, 0.14), (0.50, 0.88)),
+];
+const W: &[Seg] = &[
+    ((0.10, 0.14), (0.28, 0.88)),
+    ((0.28, 0.88), (0.50, 0.40)),
+    ((0.50, 0.40), (0.72, 0.88)),
+    ((0.72, 0.88), (0.90, 0.14)),
+];
+const X: &[Seg] = &[
+    ((0.20, 0.14), (0.80, 0.88)),
+    ((0.80, 0.14), (0.20, 0.88)),
+];
+const Y: &[Seg] = &[
+    ((0.18, 0.14), (0.50, 0.50)),
+    ((0.82, 0.14), (0.50, 0.50)),
+    ((0.50, 0.50), (0.50, 0.88)),
+];
+const Z: &[Seg] = &[
+    ((0.20, 0.14), (0.80, 0.14)),
+    ((0.80, 0.14), (0.20, 0.88)),
+    ((0.20, 0.88), (0.80, 0.88)),
+];
+const COLON: &[Seg] = &[((0.50, 0.32), (0.50, 0.32)), ((0.50, 0.70), (0.50, 0.70))];
+
+fn ink_in_rect(glyph: &[u8], x0: u32, y0: u32, x1: u32, y1: u32) -> u32 {
+    let mut s = 0u32;
+    for y in y0..y1.min(GLYPH) {
+        for x in x0..x1.min(GLYPH) {
+            s += glyph[(y * GLYPH + x) as usize] as u32;
+        }
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn atlas_is_512x96() {
+        let atlas = rasterize_atlas();
+        assert_eq!(atlas.width, 512);
+        assert_eq!(atlas.height, 96);
+        assert_eq!(atlas.pixels.len(), 512 * 96);
+        assert!(atlas.pixels.iter().any(|&p| p > 80));
+    }
+
+    #[test]
+    fn letter_a_is_upright_not_inverted() {
+        let g = raster_glyph(1);
+        // Pointed top / crossbar mid / two legs at the bottom.
+        let top = ink_in_rect(&g, 10, 2, 22, 10);
+        let mid = ink_in_rect(&g, 6, 14, 26, 20);
+        let bot_l = ink_in_rect(&g, 2, 24, 12, 31);
+        let bot_r = ink_in_rect(&g, 20, 24, 30, 31);
+        let bot_c = ink_in_rect(&g, 13, 26, 19, 31);
+        assert!(top > 800, "A should have a peak at the top, got {top}");
+        assert!(mid > top, "A crossbar should be stronger than the peak");
+        assert!(bot_l > 400 && bot_r > 400, "A should stand on two legs");
+        assert!(bot_c < bot_l.min(bot_r), "A crotch should be open at the bottom");
+    }
+
+    #[test]
+    fn letter_t_has_bar_on_top() {
+        let g = raster_glyph(20);
+        let top = ink_in_rect(&g, 2, 2, 30, 8);
+        let bot = ink_in_rect(&g, 2, 24, 30, 31);
+        let stem = ink_in_rect(&g, 13, 8, 19, 30);
+        assert!(top > bot * 2, "T bar belongs at the top, not the bottom");
+        assert!(stem > 500);
+    }
+
+    #[test]
+    fn colon_is_two_stacked_dots() {
+        let g = raster_glyph(27);
+        let upper = ink_in_rect(&g, 10, 6, 22, 14);
+        let lower = ink_in_rect(&g, 10, 18, 22, 26);
+        let left = ink_in_rect(&g, 0, 0, 8, 32);
+        assert!(upper > 200 && lower > 200);
+        assert!(left < 80, "colon should not look like a sideways pair");
+    }
+
+    #[test]
+    fn space_is_empty() {
+        let g = raster_glyph(0);
+        assert!(g.iter().all(|&p| p == 0));
+    }
+}

--- a/pycelium-win/src/main.rs
+++ b/pycelium-win/src/main.rs
@@ -2,6 +2,7 @@ mod config;
 mod cutter;
 mod export;
 mod gpu;
+mod hud_font;
 mod memory;
 mod model;
 mod types;
@@ -243,7 +244,7 @@ impl ApplicationHandler<AppAction> for App {
                 println!("[ ] depth | ; ' thickness | , . XY field | arrows pan slab | Shift = coarse");
                 println!("Space pause | R reseed | F litter | D drift | Esc quit");
                 println!(
-                    "Tab HUD labels ({}) | hover a meter to fade English | glyphs stay",
+                    "Tab HUD labels ({}) | white names + color boxes | hover in sparse",
                     self.runtime.as_ref().map(|r| r.labels.as_str()).unwrap_or("rich")
                 );
                 println!(

--- a/pycelium-win/src/main.rs
+++ b/pycelium-win/src/main.rs
@@ -1,11 +1,14 @@
 mod config;
+mod cutter;
+mod export;
 mod gpu;
 mod memory;
 mod model;
 mod types;
 
+use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Instant, SystemTime};
 
 use anyhow::Result;
 use clap::Parser;
@@ -17,6 +20,8 @@ use winit::keyboard::{Key, NamedKey};
 use winit::window::{Window, WindowId};
 
 use crate::config::{Args, LabelDensity, MemoryPlan};
+use crate::cutter::Cutter;
+use crate::export::{extract_slice, utc_stamp, write_exports};
 use crate::gpu::{GpuDevice, MyceliumGpu};
 use crate::memory::HostWorld;
 use crate::types::SimUniforms;
@@ -65,6 +70,8 @@ struct Runtime {
     shift: bool,
     labels: LabelDensity,
     label_fade: f32,
+    cutter: Cutter,
+    export_dir: PathBuf,
 }
 
 struct App {
@@ -73,6 +80,7 @@ struct App {
     world: Option<HostWorld>,
     runtime: Option<Runtime>,
     labels: LabelDensity,
+    export_dir: PathBuf,
 }
 
 fn main() -> Result<()> {
@@ -84,6 +92,7 @@ fn main() -> Result<()> {
 
     let world = HostWorld::commit(&plan)?;
     let labels = args.labels;
+    let export_dir = PathBuf::from(&args.export_dir);
 
     if let Some(frames) = args.bench {
         return run_bench(plan, world, frames);
@@ -96,6 +105,7 @@ fn main() -> Result<()> {
         world: Some(world),
         runtime: None,
         labels,
+        export_dir,
     };
     event_loop.run_app(&mut app)?;
     Ok(())
@@ -151,6 +161,8 @@ impl ApplicationHandler<AppAction> for App {
         let world = self.world.take().expect("host world");
         let vsync = plan.vsync;
         let labels = self.labels;
+        let export_dir = self.export_dir.clone();
+        let cutter_depth = plan.gpu_depth;
 
         pollster::block_on(async move {
             let instance = wgpu::Instance::new(
@@ -209,6 +221,8 @@ impl ApplicationHandler<AppAction> for App {
                 shift: false,
                 labels,
                 label_fade: if labels == LabelDensity::Off { 0.0 } else { 1.0 },
+                cutter: Cutter::new(cutter_depth),
+                export_dir,
             })));
         });
     }
@@ -231,6 +245,9 @@ impl ApplicationHandler<AppAction> for App {
                 println!(
                     "Tab HUD labels ({}) | hover a meter to fade English | glyphs stay",
                     self.runtime.as_ref().map(|r| r.labels.as_str()).unwrap_or("rich")
+                );
+                println!(
+                    "E capture | C 2D/rich | hover cube face to snap | drag slider handles | Enter export | Esc leave"
                 );
                 println!(
                     "HUD: FPS, tips, fusions, branches, C:N | bars | then slice Z / thickness / zoom% | selected tip"
@@ -268,12 +285,45 @@ impl ApplicationHandler<AppAction> for App {
                     (x as f32 / rt.config.width as f32).clamp(0.0, 1.0),
                     (y as f32 / rt.config.height as f32).clamp(0.0, 1.0),
                 );
+                if rt.cutter.active {
+                    let axis_n = rt.cutter.axis.size(rt.sim.width, rt.sim.height, rt.sim.depth)
+                        as f32;
+                    if rt.cutter.dragging.is_some() {
+                        rt.cutter.drag_handle(rt.cursor, axis_n);
+                    } else if !rt.orbit.dragging {
+                        let (eye, target) = rt.orbit.eye_target();
+                        let rd = click_dir(
+                            rt.cursor,
+                            rt.config.width,
+                            rt.config.height,
+                            eye,
+                            target,
+                        );
+                        rt.cutter.track_pointer(eye, rd, axis_n);
+                    }
+                }
             }
             WindowEvent::MouseInput { state, button, .. } => {
                 if button == MouseButton::Left {
+                    if state == ElementState::Pressed && rt.cutter.active {
+                        let axis_n = rt.cutter.axis.size(rt.sim.width, rt.sim.height, rt.sim.depth)
+                            as f32;
+                        if let Some(handle) = rt.cutter.hit_handle(rt.cursor, axis_n) {
+                            rt.cutter.dragging = Some(handle);
+                            rt.orbit.dragging = false;
+                            rt.orbit.last = None;
+                            return;
+                        }
+                    }
+                    if state == ElementState::Released && rt.cutter.dragging.is_some() {
+                        rt.cutter.dragging = None;
+                        rt.orbit.dragging = false;
+                        rt.orbit.last = None;
+                        return;
+                    }
                     rt.orbit.dragging = state == ElementState::Pressed;
                     rt.orbit.last = None;
-                    if state == ElementState::Released {
+                    if state == ElementState::Released && !rt.cutter.active {
                         rt.pending_pick = true;
                     }
                 }
@@ -283,7 +333,13 @@ impl ApplicationHandler<AppAction> for App {
                     MouseScrollDelta::LineDelta(_, y) => y,
                     MouseScrollDelta::PixelDelta(p) => p.y as f32 / 80.0,
                 };
-                rt.orbit.radius = (rt.orbit.radius - steps * 0.12).clamp(0.55, 4.5);
+                if rt.cutter.active && rt.shift {
+                    let axis_n = rt.cutter.axis.size(rt.sim.width, rt.sim.height, rt.sim.depth)
+                        as f32;
+                    rt.cutter.nudge_half(steps * if rt.shift { 2.0 } else { 1.0 }, axis_n);
+                } else {
+                    rt.orbit.radius = (rt.orbit.radius - steps * 0.12).clamp(0.55, 4.5);
+                }
             }
             WindowEvent::KeyboardInput {
                 event:
@@ -362,11 +418,56 @@ impl ApplicationHandler<AppAction> for App {
                     return;
                 }
                 match logical_key {
-                    Key::Named(NamedKey::Escape) => event_loop.exit(),
+                    Key::Named(NamedKey::Escape) => {
+                        if rt.cutter.active {
+                            rt.cutter.leave();
+                            println!("capture off");
+                            rt.window.request_redraw();
+                        } else {
+                            event_loop.exit();
+                        }
+                    }
+                    Key::Named(NamedKey::Enter) => {
+                        if rt.cutter.active {
+                            if let Err(err) = export_slice(rt) {
+                                eprintln!("slice export failed: {err:#}");
+                            }
+                        }
+                    }
                     Key::Named(NamedKey::Tab) => {
                         rt.labels = rt.labels.cycle();
                         println!("HUD labels: {}", rt.labels.as_str());
                         rt.window.request_redraw();
+                    }
+                    Key::Character(c) if c.eq_ignore_ascii_case("e") => {
+                        rt.cutter.toggle(rt.sim.slice.z, rt.sim.depth);
+                        if rt.cutter.active {
+                            println!("{}", rt.cutter.describe());
+                            println!(
+                                "C cycle 2D/rich | X axis | hover face center/mid-edge to snap | H heightmap | Y height axis | Shift+wheel thickness"
+                            );
+                        } else {
+                            println!("capture off");
+                        }
+                        rt.window.request_redraw();
+                    }
+                    Key::Character(c) if c.eq_ignore_ascii_case("c") && rt.cutter.active => {
+                        rt.cutter.cycle_mode();
+                        println!("{}", rt.cutter.describe());
+                        rt.window.request_redraw();
+                    }
+                    Key::Character(c) if c.eq_ignore_ascii_case("x") && rt.cutter.active => {
+                        rt.cutter.cycle_axis();
+                        println!("{}", rt.cutter.describe());
+                        rt.window.request_redraw();
+                    }
+                    Key::Character(c) if c.eq_ignore_ascii_case("h") && rt.cutter.active => {
+                        rt.cutter.export_heightmap = !rt.cutter.export_heightmap;
+                        println!("{}", rt.cutter.describe());
+                    }
+                    Key::Character(c) if c.eq_ignore_ascii_case("y") && rt.cutter.active => {
+                        rt.cutter.cycle_heightmap_axis();
+                        println!("{}", rt.cutter.describe());
                     }
                     Key::Named(NamedKey::Space) => rt.paused = !rt.paused,
                     Key::Character(c) if c.eq_ignore_ascii_case("r") => {
@@ -443,6 +544,12 @@ impl ApplicationHandler<AppAction> for App {
                         if (rt.label_fade - fade_target).abs() < 0.01 {
                             rt.label_fade = fade_target;
                         }
+                        if rt.cutter.active {
+                            rt.window.set_title(&format!(
+                                "Pycelium 3D | {}",
+                                rt.cutter.describe()
+                            ));
+                        }
                         rt.sim.render(
                             &rt.gpu.device,
                             &rt.gpu.queue,
@@ -456,6 +563,7 @@ impl ApplicationHandler<AppAction> for App {
                             rt.labels.as_f32(),
                             rt.label_fade,
                             rt.has_picked,
+                            rt.cutter.present_vec(),
                         );
                         rt.window.pre_present_notify();
                         rt.gpu.queue.present(frame);
@@ -472,15 +580,17 @@ impl ApplicationHandler<AppAction> for App {
                     rt.fps = rt.frames as f32 / dt;
                     rt.frames = 0;
                     rt.fps_mark = Instant::now();
-                    rt.window.set_title(&format!(
-                        "Pycelium 3D | {:.0} FPS | {}x{}x{} | {:.2} GiB | {}",
-                        rt.fps,
-                        rt.plan.gpu_width,
-                        rt.plan.gpu_height,
-                        rt.plan.gpu_depth,
-                        rt.world.committed_bytes() as f64 / 1024.0 / 1024.0 / 1024.0,
-                        rt.gpu.describe()
-                    ));
+                    if !rt.cutter.active {
+                        rt.window.set_title(&format!(
+                            "Pycelium 3D | {:.0} FPS | {}x{}x{} | {:.2} GiB | {}",
+                            rt.fps,
+                            rt.plan.gpu_width,
+                            rt.plan.gpu_height,
+                            rt.plan.gpu_depth,
+                            rt.world.committed_bytes() as f64 / 1024.0 / 1024.0 / 1024.0,
+                            rt.gpu.describe()
+                        ));
+                    }
                 }
                 rt.window.request_redraw();
             }
@@ -496,6 +606,32 @@ impl ApplicationHandler<AppAction> for App {
             }
         }
     }
+}
+
+fn export_slice(rt: &Runtime) -> anyhow::Result<()> {
+    let vol = rt
+        .sim
+        .read_volume_fields(&rt.gpu.device, &rt.gpu.queue)?;
+    let plane = extract_slice(&vol, &rt.cutter, rt.cutter.mode == crate::cutter::CaptureMode::RichBox);
+    let stamp = utc_stamp(SystemTime::now());
+    let paths = write_exports(
+        &rt.export_dir,
+        &plane,
+        &rt.cutter,
+        (rt.sim.width, rt.sim.height, rt.sim.depth),
+        &stamp,
+    )?;
+    println!(
+        "exported {}  {}  {}  {}",
+        paths.png.display(),
+        paths.json.display(),
+        paths.svg.display(),
+        paths.mask.display()
+    );
+    if let Some(h) = paths.height {
+        println!("heightmap {}", h.display());
+    }
+    Ok(())
 }
 
 fn click_dir(

--- a/pycelium-win/src/shaders/present.wgsl
+++ b/pycelium-win/src/shaders/present.wgsl
@@ -52,6 +52,8 @@ struct PresentUniforms {
 @group(0) @binding(5) var<storage, read> organic: array<f32>;
 @group(0) @binding(6) var<storage, read> hud: array<u32>;
 @group(0) @binding(7) var<storage, read> tips: array<Tip>;
+@group(0) @binding(8) var font_tex: texture_2d<f32>;
+@group(0) @binding(9) var font_samp: sampler;
 
 struct VsOut {
     @builtin(position) clip: vec4<f32>,
@@ -119,7 +121,7 @@ fn digit(cell: vec2<f32>, n: i32) -> f32 {
 }
 
 fn draw_number(uv: vec2<f32>, origin: vec2<f32>, value: f32, digits: i32) -> f32 {
-    let local = (uv - origin) / vec2<f32>(0.014 * f32(digits), 0.028);
+    let local = (uv - origin) / vec2<f32>(0.0082 * f32(digits), 0.016);
     if local.x < 0.0 || local.x > 1.0 || local.y < 0.0 || local.y > 1.0 {
         return 0.0;
     }
@@ -133,7 +135,7 @@ fn draw_number(uv: vec2<f32>, origin: vec2<f32>, value: f32, digits: i32) -> f32
 }
 
 fn bar(uv: vec2<f32>, origin: vec2<f32>, fill: f32, rgb: vec3<f32>) -> vec3<f32> {
-    let local = (uv - origin) / vec2<f32>(0.16, 0.016);
+    let local = (uv - origin) / vec2<f32>(0.11, 0.016);
     if local.x < 0.0 || local.x > 1.0 || local.y < 0.0 || local.y > 1.0 {
         return vec3<f32>(0.0);
     }
@@ -146,47 +148,17 @@ fn px() -> vec2<f32> {
     return vec2<f32>(1.0 / max(f32(u.out_w), 1.0), 1.0 / max(f32(u.out_h), 1.0));
 }
 
-// 5×5 mono capitals. Packed row-major, bit 0 = top-left. Space = 0, A–Z = 1–26, ':' = 27.
-fn letter_bits(ch: i32) -> u32 {
-    switch ch {
-        case 1: { return 0x0118FE2Eu; }  // A
-        case 2: { return 0x00F8BE2Fu; }  // B
-        case 3: { return 0x01E0843Eu; }  // C
-        case 4: { return 0x00F8C62Fu; }  // D
-        case 5: { return 0x01F0BC3Fu; }  // E
-        case 6: { return 0x0010BC3Fu; }  // F
-        case 7: { return 0x01E8E43Eu; }  // G
-        case 8: { return 0x0118FE31u; }  // H
-        case 9: { return 0x01F2109Fu; }  // I
-        case 10: { return 0x0064A11Cu; } // J
-        case 11: { return 0x01149D31u; } // K
-        case 12: { return 0x01F08421u; } // L
-        case 13: { return 0x0118D771u; } // M
-        case 14: { return 0x011CD671u; } // N
-        case 15: { return 0x00E8C62Eu; } // O
-        case 16: { return 0x0010BE2Fu; } // P
-        case 17: { return 0x01ECC62Eu; } // Q
-        case 18: { return 0x0114BE2Fu; } // R
-        case 19: { return 0x00F8383Eu; } // S
-        case 20: { return 0x0042109Fu; } // T
-        case 21: { return 0x00E8C631u; } // U
-        case 22: { return 0x00454631u; } // V
-        case 23: { return 0x011DD631u; } // W
-        case 24: { return 0x01151151u; } // X
-        case 25: { return 0x00421151u; } // Y
-        case 26: { return 0x01F1111Fu; } // Z
-        case 27: { return 0x00020080u; } // :
-        default: { return 0u; }
-    }
-}
-
+// Geometric sans atlas: 16×3 cells of 32px. cell.y = 0 is the TOP of the glyph.
+// Built in hud_font.rs (upright). The old 5×5 pack was sampled with 1-y and looked inverted.
 fn letter(cell: vec2<f32>, ch: i32) -> f32 {
     if ch <= 0 { return 0.0; }
-    let p = vec2<i32>(i32(floor(cell.x * 5.0)), i32(floor((1.0 - cell.y) * 5.0)));
-    if p.x < 0 || p.x > 4 || p.y < 0 || p.y > 4 { return 0.0; }
-    let bits = letter_bits(ch);
-    let bit = u32(p.y * 5 + p.x);
-    return f32((bits >> bit) & 1u);
+    if cell.x < 0.0 || cell.x > 1.0 || cell.y < 0.0 || cell.y > 1.0 {
+        return 0.0;
+    }
+    let col = ch % 16;
+    let row = ch / 16;
+    let uv = (vec2<f32>(f32(col), f32(row)) + cell) / vec2<f32>(16.0, 3.0);
+    return textureSampleLevel(font_tex, font_samp, uv, 0.0).r;
 }
 
 // Short English names for the left HUD. -1 terminates a string of at most 8 glyphs.
@@ -255,7 +227,7 @@ fn label_char(id: i32, slot: i32) -> i32 {
 
 fn draw_label(uv: vec2<f32>, origin: vec2<f32>, id: i32) -> f32 {
     let n = 8.0;
-    let local = (uv - origin) / vec2<f32>(0.0075 * n, 0.014);
+    let local = (uv - origin) / vec2<f32>(0.0112 * n, 0.022);
     if local.x < 0.0 || local.x > 1.0 || local.y < 0.0 || local.y > 1.0 {
         return 0.0;
     }
@@ -273,13 +245,6 @@ fn thin_frame(uv: vec2<f32>, r0: vec2<f32>, r1: vec2<f32>) -> f32 {
     return select(0.0, 1.0, inside && !inner);
 }
 
-fn elbow(uv: vec2<f32>, a: vec2<f32>, b: vec2<f32>) -> f32 {
-    let p = px();
-    let h = abs(uv.y - a.y) <= p.y && uv.x >= min(a.x, b.x) && uv.x <= max(a.x, b.x);
-    let v = abs(uv.x - b.x) <= p.x && uv.y >= min(a.y, b.y) && uv.y <= max(a.y, b.y);
-    return select(0.0, 1.0, h || v);
-}
-
 fn row_alpha(cursor: vec2<f32>, y0: f32, y1: f32, density: f32, fade: f32, picked: bool) -> f32 {
     if density < 0.5 || fade <= 0.0 {
         return 0.0;
@@ -292,8 +257,8 @@ fn row_alpha(cursor: vec2<f32>, y0: f32, y1: f32, density: f32, fade: f32, picke
     if in_panel {
         hover = 1.0 - smoothstep(half, half + 0.028, dy);
     }
-    let base = select(0.0, 0.32, density > 1.5);
-    let focus = select(base, max(base, 0.82), picked);
+    let base = select(0.0, 0.96, density > 1.5);
+    let focus = select(base, max(base, 0.96), picked);
     return clamp(max(focus, hover), 0.0, 1.0) * fade;
 }
 
@@ -301,20 +266,23 @@ fn paint_label(uv: vec2<f32>, origin: vec2<f32>, id: i32, alpha: f32, rgb: vec3<
     if alpha <= 0.004 {
         return rgb;
     }
-    let shadow = draw_label(uv, origin + px() * 2.0, id);
+    let shadow = draw_label(uv, origin + px() * 1.5, id);
     let ink = draw_label(uv, origin, id);
     var out = rgb;
-    out = mix(out, vec3<f32>(0.0, 0.0, 0.0), shadow * alpha * 0.55);
-    out = mix(out, vec3<f32>(0.94, 0.95, 0.92), ink * alpha);
+    out = mix(out, vec3<f32>(0.0, 0.0, 0.0), shadow * alpha * 0.45);
+    out = mix(out, vec3<f32>(1.0, 1.0, 1.0), ink * alpha);
     return out;
 }
 
-fn paint_callout(uv: vec2<f32>, src: vec2<f32>, dst: vec2<f32>, alpha: f32, rgb: vec3<f32>) -> vec3<f32> {
-    if alpha < 0.55 {
-        return rgb;
+fn swatch(uv: vec2<f32>, origin: vec2<f32>, fill: f32, tint: vec3<f32>) -> vec3<f32> {
+    let local = (uv - origin) / vec2<f32>(0.015, 0.018);
+    if local.x < 0.0 || local.x > 1.0 || local.y < 0.0 || local.y > 1.0 {
+        return vec3<f32>(0.0);
     }
-    let line = elbow(uv, src, dst);
-    return mix(rgb, vec3<f32>(0.86, 0.88, 0.84), line * (alpha - 0.55) * 0.9);
+    let p = px();
+    let edge = local.x < p.x / 0.015 || local.x > 1.0 - p.x / 0.015 || local.y < p.y / 0.018 || local.y > 1.0 - p.y / 0.018;
+    let body = mix(tint * 0.18, tint, clamp(fill, 0.22, 1.0));
+    return select(body, vec3<f32>(0.92, 0.93, 0.90), edge);
 }
 
 @fragment
@@ -464,9 +432,9 @@ fn fs_main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
         }
     }
 
-    // Telemetry panel. 3×5 glyphs stay; English is a fade-in overlay.
-    // Row map: docs/HUD_LEGEND.md
-    if uv.x < 0.24 {
+    // Telemetry panel. Readable white captions + color readout boxes.
+    // Optional small 3×5 digits sit to the right. Row map: docs/HUD_LEGEND.md
+    if uv.x < 0.26 {
         rgb = mix(rgb, vec3<f32>(0.03, 0.035, 0.04), 0.78);
         var ink = 0.0;
         let live = f32(hud[0]);
@@ -485,98 +453,114 @@ fn fs_main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
             age = tip.age;
             reserve = tip.reserve;
         }
-        ink = ink + draw_number(uv, vec2<f32>(0.018, 0.06), u.fps, 3);
-        ink = ink + draw_number(uv, vec2<f32>(0.018, 0.12), live, 6);
-        ink = ink + draw_number(uv, vec2<f32>(0.018, 0.16), fusions, 5);
-        ink = ink + draw_number(uv, vec2<f32>(0.018, 0.20), branches, 5);
-        ink = ink + draw_number(uv, vec2<f32>(0.018, 0.24), cn, 4);
-        ink = ink + draw_number(uv, vec2<f32>(0.018, 0.70), f32(sid), 6);
-        ink = ink + draw_number(uv, vec2<f32>(0.018, 0.74), lineage, 3);
-        ink = ink + draw_number(uv, vec2<f32>(0.018, 0.78), age, 5);
-        ink = ink + draw_number(uv, vec2<f32>(0.018, 0.82), reserve * 100.0, 4);
-        ink = ink + draw_number(uv, vec2<f32>(0.018, 0.56), u.slice_z, 4);
-        ink = ink + draw_number(uv, vec2<f32>(0.018, 0.60), u.slice_thickness, 3);
-        ink = ink + draw_number(uv, vec2<f32>(0.018, 0.64), u.slice_zoom * 100.0, 3);
-        ink = ink + draw_number(uv, vec2<f32>(0.018, 0.90), u.param_slot, 1);
-        ink = ink + draw_number(uv, vec2<f32>(0.050, 0.90), u.param_value * 100.0, 4);
-        rgb = rgb + vec3<f32>(0.82, 0.88, 0.80) * ink;
-        rgb = rgb + bar(uv, vec2<f32>(0.03, 0.32), f32(hud[4]) / 80000.0, vec3<f32>(0.55, 0.92, 0.82));
-        rgb = rgb + bar(uv, vec2<f32>(0.03, 0.36), f32(hud[5]) / 40000.0, vec3<f32>(0.95, 0.72, 0.28));
-        rgb = rgb + bar(uv, vec2<f32>(0.03, 0.40), f32(hud[6]) / 40000.0, vec3<f32>(0.78, 0.42, 0.10));
-        rgb = rgb + bar(uv, vec2<f32>(0.03, 0.44), f32(hud[7]) / 25000.0, vec3<f32>(0.55, 0.40, 0.85));
-        rgb = rgb + bar(uv, vec2<f32>(0.03, 0.48), f32(hud[8]) / 20000.0, vec3<f32>(0.32, 0.70, 0.34));
-        rgb = rgb + bar(uv, vec2<f32>(0.03, 0.52), f32(hud[9]) / 50000.0, vec3<f32>(0.45, 0.32, 0.18));
+        let hypha_f = clamp(f32(hud[4]) / 80000.0, 0.0, 1.0);
+        let cord_f = clamp(f32(hud[5]) / 40000.0, 0.0, 1.0);
+        let solc_f = clamp(f32(hud[6]) / 40000.0, 0.0, 1.0);
+        let soln_f = clamp(f32(hud[7]) / 25000.0, 0.0, 1.0);
+        let enz_f = clamp(f32(hud[8]) / 20000.0, 0.0, 1.0);
+        let org_f = clamp(f32(hud[9]) / 50000.0, 0.0, 1.0);
+        let teal = vec3<f32>(0.55, 0.92, 0.82);
+        let amber = vec3<f32>(0.95, 0.72, 0.28);
+        let rust = vec3<f32>(0.78, 0.42, 0.10);
+        let violet = vec3<f32>(0.55, 0.40, 0.85);
+        let green = vec3<f32>(0.32, 0.70, 0.34);
+        let brown = vec3<f32>(0.45, 0.32, 0.18);
+        let ice = vec3<f32>(0.78, 0.84, 0.88);
+        let gold = vec3<f32>(0.90, 0.78, 0.40);
+        let warm = vec3<f32>(0.92, 0.62, 0.28);
+
+        ink = ink + draw_number(uv, vec2<f32>(0.168, 0.058), u.fps, 3);
+        ink = ink + draw_number(uv, vec2<f32>(0.168, 0.100), live, 6);
+        ink = ink + draw_number(uv, vec2<f32>(0.168, 0.142), fusions, 5);
+        ink = ink + draw_number(uv, vec2<f32>(0.168, 0.184), branches, 5);
+        ink = ink + draw_number(uv, vec2<f32>(0.168, 0.226), cn, 4);
+        ink = ink + draw_number(uv, vec2<f32>(0.168, 0.558), u.slice_z, 4);
+        ink = ink + draw_number(uv, vec2<f32>(0.168, 0.600), u.slice_thickness, 3);
+        ink = ink + draw_number(uv, vec2<f32>(0.168, 0.642), u.slice_zoom * 100.0, 3);
+        ink = ink + draw_number(uv, vec2<f32>(0.168, 0.700), f32(sid), 6);
+        ink = ink + draw_number(uv, vec2<f32>(0.168, 0.742), lineage, 3);
+        ink = ink + draw_number(uv, vec2<f32>(0.168, 0.784), age, 5);
+        ink = ink + draw_number(uv, vec2<f32>(0.168, 0.826), reserve * 100.0, 4);
+        ink = ink + draw_number(uv, vec2<f32>(0.168, 0.896), u.param_slot, 1);
+        ink = ink + draw_number(uv, vec2<f32>(0.188, 0.896), u.param_value * 100.0, 4);
+        rgb = rgb + vec3<f32>(0.70, 0.76, 0.72) * ink * 0.85;
+        rgb = rgb + bar(uv, vec2<f32>(0.128, 0.312), hypha_f, teal);
+        rgb = rgb + bar(uv, vec2<f32>(0.128, 0.354), cord_f, amber);
+        rgb = rgb + bar(uv, vec2<f32>(0.128, 0.396), solc_f, rust);
+        rgb = rgb + bar(uv, vec2<f32>(0.128, 0.438), soln_f, violet);
+        rgb = rgb + bar(uv, vec2<f32>(0.128, 0.480), enz_f, green);
+        rgb = rgb + bar(uv, vec2<f32>(0.128, 0.522), org_f, brown);
+
+        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.058), 0.85, ice);
+        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.100), clamp(live / 400000.0, 0.2, 1.0), teal);
+        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.142), clamp(fusions / 8000.0, 0.2, 1.0), amber);
+        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.184), clamp(branches / 8000.0, 0.2, 1.0), green);
+        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.226), clamp(cn / 12.0, 0.2, 1.0), rust);
+        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.318), hypha_f, teal);
+        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.360), cord_f, amber);
+        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.402), solc_f, rust);
+        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.444), soln_f, violet);
+        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.486), enz_f, green);
+        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.528), org_f, brown);
+        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.558), 0.7, warm);
+        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.600), 0.55, warm);
+        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.642), 0.4, warm);
+        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.700), select(0.25, 0.9, sid < 20000000u), teal);
+        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.742), select(0.25, 0.75, sid < 20000000u), gold);
+        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.784), select(0.25, 0.6, sid < 20000000u), ice);
+        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.826), select(0.25, clamp(reserve, 0.25, 1.0), sid < 20000000u), amber);
+        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.896), 0.7, ice);
 
         let cursor = u.hud_ui.xy;
         let density = u.hud_ui.z;
         let fade = clamp(u.hud_ui.w, 0.0, 1.0);
         let picked = sid < 20000000u && u.selected_id > 0.0;
-        let chrome = row_alpha(cursor, 0.04, 0.96, density, fade, false) * 0.55;
-        rgb = mix(rgb, vec3<f32>(0.72, 0.74, 0.70), thin_frame(uv, vec2<f32>(0.008, 0.048), vec2<f32>(0.232, 0.288)) * chrome);
-        rgb = mix(rgb, vec3<f32>(0.72, 0.74, 0.70), thin_frame(uv, vec2<f32>(0.008, 0.300), vec2<f32>(0.232, 0.548)) * chrome);
-        rgb = mix(rgb, vec3<f32>(0.72, 0.74, 0.70), thin_frame(uv, vec2<f32>(0.008, 0.548), vec2<f32>(0.232, 0.682)) * chrome);
-        rgb = mix(rgb, vec3<f32>(0.72, 0.74, 0.70), thin_frame(uv, vec2<f32>(0.008, 0.688), vec2<f32>(0.232, 0.862)) * chrome);
-        rgb = mix(rgb, vec3<f32>(0.72, 0.74, 0.70), thin_frame(uv, vec2<f32>(0.008, 0.878), vec2<f32>(0.232, 0.938)) * chrome);
+        let chrome = row_alpha(cursor, 0.04, 0.96, density, fade, false) * 0.45;
+        rgb = mix(rgb, vec3<f32>(0.72, 0.74, 0.70), thin_frame(uv, vec2<f32>(0.008, 0.048), vec2<f32>(0.250, 0.258)) * chrome);
+        rgb = mix(rgb, vec3<f32>(0.72, 0.74, 0.70), thin_frame(uv, vec2<f32>(0.008, 0.300), vec2<f32>(0.250, 0.548)) * chrome);
+        rgb = mix(rgb, vec3<f32>(0.72, 0.74, 0.70), thin_frame(uv, vec2<f32>(0.008, 0.548), vec2<f32>(0.250, 0.682)) * chrome);
+        rgb = mix(rgb, vec3<f32>(0.72, 0.74, 0.70), thin_frame(uv, vec2<f32>(0.008, 0.688), vec2<f32>(0.250, 0.862)) * chrome);
+        rgb = mix(rgb, vec3<f32>(0.72, 0.74, 0.70), thin_frame(uv, vec2<f32>(0.008, 0.878), vec2<f32>(0.250, 0.938)) * chrome);
 
-        let a0 = row_alpha(cursor, 0.050, 0.100, density, fade, false);
-        let a1 = row_alpha(cursor, 0.105, 0.150, density, fade, false);
-        let a2 = row_alpha(cursor, 0.150, 0.185, density, fade, false);
-        let a3 = row_alpha(cursor, 0.185, 0.225, density, fade, false);
-        let a4 = row_alpha(cursor, 0.225, 0.280, density, fade, false);
-        let a5 = row_alpha(cursor, 0.305, 0.345, density, fade, false);
-        let a6 = row_alpha(cursor, 0.345, 0.385, density, fade, false);
-        let a7 = row_alpha(cursor, 0.385, 0.425, density, fade, false);
-        let a8 = row_alpha(cursor, 0.425, 0.465, density, fade, false);
-        let a9 = row_alpha(cursor, 0.465, 0.505, density, fade, false);
-        let a10 = row_alpha(cursor, 0.505, 0.545, density, fade, false);
-        let a11 = row_alpha(cursor, 0.545, 0.585, density, fade, false);
-        let a12 = row_alpha(cursor, 0.585, 0.625, density, fade, false);
-        let a13 = row_alpha(cursor, 0.625, 0.675, density, fade, false);
-        let a14 = row_alpha(cursor, 0.675, 0.725, density, fade, picked);
-        let a15 = row_alpha(cursor, 0.725, 0.765, density, fade, picked);
-        let a16 = row_alpha(cursor, 0.765, 0.805, density, fade, picked);
-        let a17 = row_alpha(cursor, 0.805, 0.855, density, fade, picked);
-        let a18 = row_alpha(cursor, 0.855, 0.940, density, fade, false);
+        let a0 = row_alpha(cursor, 0.050, 0.095, density, fade, false);
+        let a1 = row_alpha(cursor, 0.095, 0.137, density, fade, false);
+        let a2 = row_alpha(cursor, 0.137, 0.179, density, fade, false);
+        let a3 = row_alpha(cursor, 0.179, 0.221, density, fade, false);
+        let a4 = row_alpha(cursor, 0.221, 0.268, density, fade, false);
+        let a5 = row_alpha(cursor, 0.305, 0.350, density, fade, false);
+        let a6 = row_alpha(cursor, 0.350, 0.392, density, fade, false);
+        let a7 = row_alpha(cursor, 0.392, 0.434, density, fade, false);
+        let a8 = row_alpha(cursor, 0.434, 0.476, density, fade, false);
+        let a9 = row_alpha(cursor, 0.476, 0.518, density, fade, false);
+        let a10 = row_alpha(cursor, 0.518, 0.555, density, fade, false);
+        let a11 = row_alpha(cursor, 0.548, 0.592, density, fade, false);
+        let a12 = row_alpha(cursor, 0.592, 0.634, density, fade, false);
+        let a13 = row_alpha(cursor, 0.634, 0.682, density, fade, false);
+        let a14 = row_alpha(cursor, 0.688, 0.734, density, fade, picked);
+        let a15 = row_alpha(cursor, 0.734, 0.776, density, fade, picked);
+        let a16 = row_alpha(cursor, 0.776, 0.818, density, fade, picked);
+        let a17 = row_alpha(cursor, 0.818, 0.862, density, fade, picked);
+        let a18 = row_alpha(cursor, 0.878, 0.940, density, fade, false);
 
-        rgb = paint_label(uv, vec2<f32>(0.068, 0.067), 0, a0, rgb);
-        rgb = paint_label(uv, vec2<f32>(0.112, 0.127), 1, a1, rgb);
-        rgb = paint_label(uv, vec2<f32>(0.098, 0.167), 2, a2, rgb);
-        rgb = paint_label(uv, vec2<f32>(0.098, 0.207), 3, a3, rgb);
-        rgb = paint_label(uv, vec2<f32>(0.084, 0.247), 4, a4, rgb);
-        rgb = paint_label(uv, vec2<f32>(0.032, 0.304), 5, a5, rgb);
-        rgb = paint_label(uv, vec2<f32>(0.032, 0.344), 6, a6, rgb);
-        rgb = paint_label(uv, vec2<f32>(0.032, 0.384), 7, a7, rgb);
-        rgb = paint_label(uv, vec2<f32>(0.032, 0.424), 8, a8, rgb);
-        rgb = paint_label(uv, vec2<f32>(0.032, 0.464), 9, a9, rgb);
-        rgb = paint_label(uv, vec2<f32>(0.032, 0.504), 10, a10, rgb);
-        rgb = paint_label(uv, vec2<f32>(0.084, 0.567), 11, a11, rgb);
-        rgb = paint_label(uv, vec2<f32>(0.070, 0.607), 12, a12, rgb);
-        rgb = paint_label(uv, vec2<f32>(0.070, 0.647), 13, a13, rgb);
-        rgb = paint_label(uv, vec2<f32>(0.112, 0.707), 14, a14, rgb);
-        rgb = paint_label(uv, vec2<f32>(0.070, 0.747), 15, a15, rgb);
-        rgb = paint_label(uv, vec2<f32>(0.098, 0.787), 16, a16, rgb);
-        rgb = paint_label(uv, vec2<f32>(0.084, 0.827), 17, a17, rgb);
-        rgb = paint_label(uv, vec2<f32>(0.118, 0.907), 18, a18, rgb);
-
-        rgb = paint_callout(uv, vec2<f32>(0.062, 0.074), vec2<f32>(0.066, 0.074), a0, rgb);
-        rgb = paint_callout(uv, vec2<f32>(0.104, 0.134), vec2<f32>(0.110, 0.134), a1, rgb);
-        rgb = paint_callout(uv, vec2<f32>(0.090, 0.174), vec2<f32>(0.096, 0.174), a2, rgb);
-        rgb = paint_callout(uv, vec2<f32>(0.090, 0.214), vec2<f32>(0.096, 0.214), a3, rgb);
-        rgb = paint_callout(uv, vec2<f32>(0.076, 0.254), vec2<f32>(0.082, 0.254), a4, rgb);
-        rgb = paint_callout(uv, vec2<f32>(0.028, 0.328), vec2<f32>(0.028, 0.311), a5, rgb);
-        rgb = paint_callout(uv, vec2<f32>(0.028, 0.368), vec2<f32>(0.028, 0.351), a6, rgb);
-        rgb = paint_callout(uv, vec2<f32>(0.028, 0.408), vec2<f32>(0.028, 0.391), a7, rgb);
-        rgb = paint_callout(uv, vec2<f32>(0.028, 0.448), vec2<f32>(0.028, 0.431), a8, rgb);
-        rgb = paint_callout(uv, vec2<f32>(0.028, 0.488), vec2<f32>(0.028, 0.471), a9, rgb);
-        rgb = paint_callout(uv, vec2<f32>(0.028, 0.528), vec2<f32>(0.028, 0.511), a10, rgb);
-        rgb = paint_callout(uv, vec2<f32>(0.076, 0.574), vec2<f32>(0.082, 0.574), a11, rgb);
-        rgb = paint_callout(uv, vec2<f32>(0.062, 0.614), vec2<f32>(0.068, 0.614), a12, rgb);
-        rgb = paint_callout(uv, vec2<f32>(0.062, 0.654), vec2<f32>(0.068, 0.654), a13, rgb);
-        rgb = paint_callout(uv, vec2<f32>(0.104, 0.714), vec2<f32>(0.110, 0.714), a14, rgb);
-        rgb = paint_callout(uv, vec2<f32>(0.062, 0.754), vec2<f32>(0.068, 0.754), a15, rgb);
-        rgb = paint_callout(uv, vec2<f32>(0.090, 0.794), vec2<f32>(0.096, 0.794), a16, rgb);
-        rgb = paint_callout(uv, vec2<f32>(0.076, 0.834), vec2<f32>(0.082, 0.834), a17, rgb);
-        rgb = paint_callout(uv, vec2<f32>(0.108, 0.914), vec2<f32>(0.116, 0.914), a18, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.054), 0, a0, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.096), 1, a1, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.138), 2, a2, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.180), 3, a3, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.222), 4, a4, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.308), 5, a5, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.350), 6, a6, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.392), 7, a7, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.434), 8, a8, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.476), 9, a9, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.518), 10, a10, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.554), 11, a11, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.596), 12, a12, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.638), 13, a13, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.696), 14, a14, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.738), 15, a15, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.780), 16, a16, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.822), 17, a17, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.892), 18, a18, rgb);
     }
 
     return vec4<f32>(rgb, 1.0);

--- a/pycelium-win/src/shaders/present.wgsl
+++ b/pycelium-win/src/shaders/present.wgsl
@@ -41,6 +41,7 @@ struct PresentUniforms {
     slice_ox: f32,
     slice_oy: f32,
     hud_ui: vec4<f32>,
+    cutter: vec4<f32>,
 }
 
 @group(0) @binding(0) var<uniform> u: PresentUniforms;
@@ -350,11 +351,36 @@ fn fs_main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
             col = col + vec3<f32>(0.72, 0.38, 0.08) * food * 0.45;
             col = col + vec3<f32>(0.28, 0.62, 0.30) * enz * 0.25;
             col = col + vec3<f32>(0.12, 0.08, 0.05) * (1.0 - exp(-org * 1.4)) * 0.2;
-            let dens = hypha * 0.55 + cord * 0.2 + food * 0.08 + 0.015;
+            var dens = hypha * 0.55 + cord * 0.2 + food * 0.08 + 0.015;
             let z_vox = p.z * f32(u.depth);
             let slab = abs(z_vox - u.slice_z) <= max(u.slice_thickness * 0.5, 0.5);
             if slab {
                 col = col + vec3<f32>(0.35, 0.28, 0.08);
+            }
+            let capture = u.cutter.w;
+            if capture >= 0.5 {
+                let vol = vec3<f32>(f32(u.width), f32(u.height), f32(u.depth));
+                let pv = p * vol;
+                let ax = i32(u.cutter.x + 0.5);
+                var coord = pv.z;
+                var asz = vol.z;
+                if ax == 0 {
+                    coord = pv.x;
+                    asz = vol.x;
+                } else if ax == 1 {
+                    coord = pv.y;
+                    asz = vol.y;
+                }
+                let center = u.cutter.y * asz;
+                let half = max(u.cutter.z, 0.5);
+                let dist = abs(coord - center);
+                if dist <= half {
+                    let face = abs(dist - half) < 0.65;
+                    let glow = select(0.28, 0.95, face);
+                    let snap = select(0.0, 0.18, fract(capture) > 0.25);
+                    col = col + vec3<f32>(1.0, 0.48, 0.08) * (glow + snap);
+                    dens = dens + select(0.03, 0.07, face);
+                }
             }
             acc = acc + (1.0 - alpha) * col * dens;
             alpha = alpha + (1.0 - alpha) * dens;
@@ -389,6 +415,53 @@ fn fs_main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
         srgb = srgb + vec3<f32>(0.7, 0.36, 0.08) * food;
         let frame = step(min(min(iu, iv), min(1.0 - iu, 1.0 - iv)), 0.02);
         rgb = mix(srgb, vec3<f32>(0.8, 0.8, 0.75), frame);
+    }
+
+    // Capture cutter: snapped cube-face wash + two-ended thickness slider.
+    if u.cutter.w >= 0.5 {
+        if hit.y > hit.x && hit.y > 0.0 && fract(u.cutter.w) > 0.25 {
+            let p0 = eye + rd * max(hit.x, 0.0);
+            let ax = i32(u.cutter.x + 0.5);
+            var face_d = min(p0.z, 1.0 - p0.z);
+            if ax == 0 { face_d = min(p0.x, 1.0 - p0.x); }
+            else if ax == 1 { face_d = min(p0.y, 1.0 - p0.y); }
+            if face_d < 0.014 {
+                rgb = mix(rgb, vec3<f32>(1.0, 0.50, 0.10), 0.22);
+            }
+        }
+        let sx0 = 0.30;
+        let sx1 = 0.70;
+        let sy0 = 0.900;
+        let sy1 = 0.958;
+        if uv.x >= sx0 - 0.012 && uv.x <= sx1 + 0.012 && uv.y >= sy0 && uv.y <= sy1 {
+            let t = clamp((uv.x - sx0) / (sx1 - sx0), 0.0, 1.0);
+            let pos = u.cutter.y;
+            var asz = f32(u.depth);
+            let ax = i32(u.cutter.x + 0.5);
+            if ax == 0 { asz = f32(u.width); }
+            else if ax == 1 { asz = f32(u.height); }
+            let hn = clamp(u.cutter.z / max(asz, 1.0), 0.0, 0.5);
+            let lo = pos - hn;
+            let hi = pos + hn;
+            var srgb = vec3<f32>(0.07, 0.07, 0.08);
+            if t >= lo && t <= hi {
+                srgb = vec3<f32>(0.85, 0.42, 0.08);
+            }
+            let track = abs(uv.y - 0.5 * (sy0 + sy1)) < 0.003;
+            if track {
+                srgb = vec3<f32>(0.35, 0.32, 0.28);
+            }
+            let handle = (abs(t - lo) < 0.012 || abs(t - hi) < 0.012) && abs(uv.y - 0.5 * (sy0 + sy1)) < 0.018;
+            if handle {
+                srgb = vec3<f32>(1.0, 0.62, 0.18);
+            }
+            let mid = abs(t - pos) < 0.004;
+            if mid {
+                srgb = vec3<f32>(0.95, 0.90, 0.70);
+            }
+            let frame = step(min(min((uv.x - (sx0 - 0.008)), (sx1 + 0.008) - uv.x), min(uv.y - sy0, sy1 - uv.y)), 0.002);
+            rgb = mix(srgb, vec3<f32>(0.80, 0.78, 0.70), frame);
+        }
     }
 
     // Telemetry panel. 3×5 glyphs stay; English is a fade-in overlay.

--- a/pycelium-win/src/types.rs
+++ b/pycelium-win/src/types.rs
@@ -188,6 +188,9 @@ pub struct PresentUniforms {
     pub slice_oy: f32,
     /// xy = cursor UV, z = label density (0 off / 1 sparse / 2 rich), w = fade 0..1
     pub hud_ui: [f32; 4],
+    /// Capture cutter: x = axis (0/1/2), y = pos 0..1, z = half-thickness voxels,
+    /// w = 0 off / 1 squash / 2 rich (+0.5 when face-snapped).
+    pub cutter: [f32; 4],
 }
 
 /// Orthogonal section through the pedon. Depth is the plane; thickness is
@@ -247,6 +250,7 @@ mod tests {
     #[test]
     fn present_uniforms_stay_16_byte_aligned() {
         assert_eq!(std::mem::size_of::<PresentUniforms>() % 16, 0);
-        assert!(std::mem::size_of::<PresentUniforms>() >= 160);
+        assert!(std::mem::size_of::<PresentUniforms>() >= 176);
+        assert_eq!(std::mem::size_of::<PresentUniforms>(), 11 * 16);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Capture a face-aligned 2D squash or rich box from the GPU mesocosm and write PNG + JSON + SVG (plus a density mask, optional heightmap). HUD English is now readable.

## HUD (this follow-up)
The old 5×5 captions were sampled with a Y flip against top-left bit packing, so they looked inverted / noisy, and rich mode drew them at 32% opacity.

- White geometric sans-serif names (stroked atlas in `hud_font.rs`, `cell.y = 0` is the top)
- Color readout box on every row (teal / amber / rust / violet / green / brown, fill tracks the meter)
- Small 3×5 digits stay on the right as optional dense telemetry
- **Tab** still cycles rich → sparse → off. Rich is full-opacity English; off keeps boxes + bars + digits
- Docs: [docs/HUD_LEGEND.md](docs/HUD_LEGEND.md)

## Slice export
- `E` enters capture (starts as 1-layer 2D squash on the current view depth)
- Mouse positions the cutter; hover a **cube face center** to snap axis (vertical / horizontal). Mid-edge hover rotates 90° on the free axis
- `C` cycles 2D squash ↔ rich box; orange plane/box preview follows the snap
- Drag the bottom two-ended slider handles (or Shift+wheel) to thicken
- `Enter` writes timestamped files under `exports/` (`--export-dir` to override)
- `Esc` leaves capture (still quits when capture is off)
- Orbit, pick, and view-slice keys are unchanged

Docs: [docs/SLICE_EXPORT.md](docs/SLICE_EXPORT.md)

`cargo test -p pycelium-win`: 34 passed (font upright A/T/colon, snap, squash, PNG/JSON/SVG, present.wgsl).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ee39710-949c-4113-a137-4d933e42ba4e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ee39710-949c-4113-a137-4d933e42ba4e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

