### PR TITLE
Export settings: square POT presets (8…8K)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ python pycelium.py
 
 ### GPU mesocosm (`pycelium-win`)
 
-Windows / wgpu 3D pedon. Left telemetry HUD uses **white sans-serif English** plus a color readout box per row (rich by default; **Tab** cycles rich / sparse / off). Small 3×5 digits stay on the right. Legend: [docs/HUD_LEGEND.md](docs/HUD_LEGEND.md). Face-aligned **slice export** (`E` capture, `Enter` write PNG/JSON/SVG): [docs/SLICE_EXPORT.md](docs/SLICE_EXPORT.md).
+Windows / wgpu 3D pedon. Left telemetry HUD uses **white sans-serif English** plus a color readout box per row (rich by default; **Tab** cycles rich / sparse / off). Small 3×5 digits stay on the right. Legend: [docs/HUD_LEGEND.md](docs/HUD_LEGEND.md). Face-aligned **slice export** (`E` capture, `S` settings, `Enter` write PNG/JSON/SVG) defaults to a **512×512** power-of-two square (presets 8…8192): [docs/SLICE_EXPORT.md](docs/SLICE_EXPORT.md).
 
 ```bash
 cargo run -p pycelium-win --release -- --preset demo
 # Tab: label density    hover a meter to focus    --labels sparse|off
-# E: capture slice    C: 2D/rich    hover a cube face to snap    Enter: export
+# E: capture slice    S: export size (8…8K square)    C: 2D/rich    Enter: export
 # --bench N is headless and does not open the HUD
 ```
 

--- a/docs/HUD_LEGEND.md
+++ b/docs/HUD_LEGEND.md
@@ -70,7 +70,7 @@ After a pick, sparse mode keeps this block readable.
 
 Slots: chemotropism, nitrotropism, autotropism, persistence, maintenance, enzyme_k, branch_cost, extension. Keys `1–8` select, `-` / `=` nudge.
 
-Slice **export** (face-aligned 2D squash / rich box) is a separate capture mode (`E`). It does not change these HUD rows. See [SLICE_EXPORT.md](SLICE_EXPORT.md).
+Slice **export** (face-aligned 2D squash / rich box) is a separate capture mode (`E`). It does not change these HUD rows. The export settings card (`S`) lives on the **right**, under the slab inset. See [SLICE_EXPORT.md](SLICE_EXPORT.md).
 
 ## Inset (right)
 

--- a/docs/SLICE_EXPORT.md
+++ b/docs/SLICE_EXPORT.md
@@ -10,10 +10,13 @@ Orbit, tip pick, HUD glyphs/labels, and **Tab** label density are unchanged. Cap
 |-----|--------|
 | `E` | Toggle capture mode |
 | `C` | Cycle **2D squash** ↔ **rich box** (while capturing) |
+| `S` | Toggle the **export settings** card (while capturing) |
+| `P` | Cycle **pad** ↔ **crop** to dense AABB |
+| `A` | Cycle **square POT** ↔ **native** aspect (advanced) |
 | `Enter` | Write files (timestamped stem) |
-| `Esc` | Leave capture (quit only when capture is off) |
+| `Esc` | Close settings if open; otherwise leave capture (quit only when capture is off) |
 
-Mouse move positions the cutter through the cube. Left-drag still orbits unless you grab a slider handle. Click-to-pick is disabled while capturing.
+Mouse move positions the cutter through the cube. Left-drag still orbits unless you grab a slider handle or click the settings card. Click-to-pick is disabled while capturing.
 
 ## Two capture modes
 
@@ -31,6 +34,20 @@ Hover a **face mid-edge** to rotate **90° on the free axis** (top-face left/rig
 
 `X` cycles axis by hand if snap misses. `Y` cycles the optional heightmap axis (and turns heightmap export on). `H` toggles writing the heightmap PNG.
 
+## Export settings (square POT)
+
+Default bake is a **power-of-two square**, not the ultra-wide native slab. The in-engine settings card sits on the right under the slab inset while capturing. Click the **EXPORT** chip (or press `S`) to open it.
+
+| Control | Default | Notes |
+|---------|---------|--------|
+| Size preset | **512×512** | 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, **8192 (8K)**. Click a row, or wheel over the card. |
+| Fit | **Pad** | Letterbox / pillarbox the full plane into the square. **Crop** trims to the occupied density AABB first, then pads. |
+| Aspect | **Square** | Advanced: **Native** keeps the extracted slab width×height (old behavior). Size presets apply only to square. |
+
+Formats are unchanged: PNG, density mask, JSON, SVG, optional heightmap (`H` / `Y`). The card lists those names; heightmap stays a key toggle.
+
+PNG / mask / SVG / `density_u8` are written at the chosen output size. JSON also records `export_aspect`, `export_fit`, `export_preset`, `source_width`, and `source_height`.
+
 ## Thickness
 
 - Bottom **two-ended slider**: center follows cursor depth along the snapped axis; drag either handle to grow N / box thickness (always symmetric).
@@ -47,15 +64,15 @@ Stem: `exports/pycelium_<YYYYMMDD_HHMMSS>_<axis>_<squash|rich>.*`
 | `.png` | Density / biomass view (teal hypha + rust soluble C, same look as the inset) |
 | `_mask.png` | Greyscale density mask (max-normalized) for later texture / material use |
 | `_height.png` | Optional. Greyscale along the chosen domain axis (black↔white). `H` / `Y`. |
-| `.json` | `pycelium-slice-v1`: grid meta, axis, thickness, stats, `density_u8`, rich `samples` |
+| `.json` | `pycelium-slice-v1`: grid meta, axis, thickness, stats, `density_u8`, rich `samples`, plus `export_aspect` / `export_fit` / `export_preset` / source size |
 | `.svg` | Marching-squares contours of high-density regions |
 
 ## CLI
 
 ```bash
 cargo run -p pycelium-win --release -- --preset demo
-# E enter capture   hover a face   C rich/2D   Enter write
+# E enter capture   hover a face   C rich/2D   S settings   Enter write
 cargo run -p pycelium-win --release -- --export-dir D:\captures
 ```
 
-`--export-dir` does not change RAM / GPU presets. `--bench` stays headless and does not export.
+`--export-dir` does not change RAM / GPU presets. `--bench` stays headless and does not export. Export size is chosen in the capture settings card (default 512×512 square), not from the CLI.

--- a/pycelium-win/src/export.rs
+++ b/pycelium-win/src/export.rs
@@ -9,6 +9,7 @@ use anyhow::{Context, Result};
 use serde::Serialize;
 
 use crate::cutter::{Axis, CaptureMode, Cutter};
+use crate::export_settings::{ExportAspect, ExportSettings, FitMode};
 
 #[derive(Clone, Debug)]
 pub struct VolumeFields {
@@ -80,6 +81,11 @@ struct SliceJson {
     plane: PlaneMeta,
     heightmap_axis: &'static str,
     heightmap: bool,
+    export_aspect: &'static str,
+    export_fit: &'static str,
+    export_preset: u32,
+    source_width: u32,
+    source_height: u32,
     stats: SliceStats,
     density_encoding: &'static str,
     density_u8: Vec<u8>,
@@ -232,12 +238,157 @@ pub fn plane_stats(plane: &SlicePlane) -> SliceStats {
     }
 }
 
+/// Crop to the occupied density AABB and/or letterbox into a square POT canvas.
+pub fn apply_export_layout(plane: &SlicePlane, settings: &ExportSettings) -> SlicePlane {
+    let work = match settings.fit {
+        FitMode::CropAabb => crop_to_dense_aabb(plane),
+        FitMode::Pad => plane.clone(),
+    };
+    match settings.aspect {
+        ExportAspect::Square => letterbox_to(&work, settings.square_size(), settings.square_size()),
+        ExportAspect::Native => work,
+    }
+}
+
+fn dense_threshold(plane: &SlicePlane) -> f32 {
+    let max_b = plane.biomass.iter().copied().fold(0.0f32, f32::max);
+    (max_b * 0.15).max(0.02)
+}
+
+fn crop_to_dense_aabb(plane: &SlicePlane) -> SlicePlane {
+    let t = dense_threshold(plane);
+    let mut x0 = plane.width;
+    let mut y0 = plane.height;
+    let mut x1 = 0u32;
+    let mut y1 = 0u32;
+    for v in 0..plane.height {
+        for u in 0..plane.width {
+            let i = (v * plane.width + u) as usize;
+            if plane.biomass[i] > t {
+                x0 = x0.min(u);
+                y0 = y0.min(v);
+                x1 = x1.max(u);
+                y1 = y1.max(v);
+            }
+        }
+    }
+    if x0 > x1 {
+        return plane.clone();
+    }
+    let x0 = x0.saturating_sub(1);
+    let y0 = y0.saturating_sub(1);
+    let x1 = (x1 + 1).min(plane.width.saturating_sub(1));
+    let y1 = (y1 + 1).min(plane.height.saturating_sub(1));
+    crop_rect(plane, x0, y0, x1, y1)
+}
+
+fn crop_rect(plane: &SlicePlane, x0: u32, y0: u32, x1: u32, y1: u32) -> SlicePlane {
+    let width = x1.saturating_sub(x0) + 1;
+    let height = y1.saturating_sub(y0) + 1;
+    let n = (width as usize).saturating_mul(height as usize);
+    let mut biomass = vec![0.0f32; n];
+    let mut soluble = vec![0.0f32; n];
+    let mut height_along = vec![0.0f32; n];
+    for v in 0..height {
+        for u in 0..width {
+            let src = ((y0 + v) * plane.width + (x0 + u)) as usize;
+            let dst = (v * width + u) as usize;
+            biomass[dst] = plane.biomass[src];
+            soluble[dst] = plane.soluble[src];
+            height_along[dst] = plane.height_along[src];
+        }
+    }
+    let mut out = plane.clone();
+    out.width = width;
+    out.height = height;
+    out.biomass = biomass;
+    out.soluble = soluble;
+    out.height_along = height_along;
+    out
+}
+
+fn letterbox_to(plane: &SlicePlane, dst_w: u32, dst_h: u32) -> SlicePlane {
+    if dst_w == 0 || dst_h == 0 {
+        return plane.clone();
+    }
+    if plane.width == dst_w && plane.height == dst_h {
+        return plane.clone();
+    }
+    let sw = plane.width.max(1) as f32;
+    let sh = plane.height.max(1) as f32;
+    let scale = (dst_w as f32 / sw).min(dst_h as f32 / sh);
+    let nw = sw * scale;
+    let nh = sh * scale;
+    let ox = (dst_w as f32 - nw) * 0.5;
+    let oy = (dst_h as f32 - nh) * 0.5;
+    let n = (dst_w as usize).saturating_mul(dst_h as usize);
+    let mut biomass = vec![0.0f32; n];
+    let mut soluble = vec![0.0f32; n];
+    let mut height_along = vec![0.0f32; n];
+    for v in 0..dst_h {
+        for u in 0..dst_w {
+            let sx = (u as f32 + 0.5 - ox) / scale - 0.5;
+            let sy = (v as f32 + 0.5 - oy) / scale - 0.5;
+            let i = (v * dst_w + u) as usize;
+            if sx < -0.5 || sy < -0.5 || sx > sw - 0.5 || sy > sh - 0.5 {
+                continue;
+            }
+            biomass[i] = sample_bilinear(&plane.biomass, plane.width, plane.height, sx, sy);
+            soluble[i] = sample_bilinear(&plane.soluble, plane.width, plane.height, sx, sy);
+            height_along[i] =
+                sample_bilinear(&plane.height_along, plane.width, plane.height, sx, sy);
+        }
+    }
+    let mut out = plane.clone();
+    out.width = dst_w;
+    out.height = dst_h;
+    out.biomass = biomass;
+    out.soluble = soluble;
+    out.height_along = height_along;
+    out
+}
+
+fn sample_bilinear(field: &[f32], w: u32, h: u32, x: f32, y: f32) -> f32 {
+    if w == 0 || h == 0 || field.is_empty() {
+        return 0.0;
+    }
+    let x0 = x.floor() as i32;
+    let y0 = y.floor() as i32;
+    let tx = (x - x0 as f32).clamp(0.0, 1.0);
+    let ty = (y - y0 as f32).clamp(0.0, 1.0);
+    let at = |ix: i32, iy: i32| -> f32 {
+        if ix < 0 || iy < 0 || ix >= w as i32 || iy >= h as i32 {
+            return 0.0;
+        }
+        field[(iy as u32 * w + ix as u32) as usize]
+    };
+    let a = at(x0, y0);
+    let b = at(x0 + 1, y0);
+    let c = at(x0, y0 + 1);
+    let d = at(x0 + 1, y0 + 1);
+    let top = a * (1.0 - tx) + b * tx;
+    let bot = c * (1.0 - tx) + d * tx;
+    top * (1.0 - ty) + bot * ty
+}
+
 pub fn write_exports(
     dir: &Path,
     plane: &SlicePlane,
     cutter: &Cutter,
     grid: (u32, u32, u32),
     stamp: &str,
+) -> Result<ExportPaths> {
+    write_exports_with_meta(dir, plane, cutter, grid, stamp, None, (plane.width, plane.height))
+}
+
+pub fn write_exports_with_meta(
+    dir: &Path,
+    plane: &SlicePlane,
+    cutter: &Cutter,
+    grid: (u32, u32, u32),
+    stamp: &str,
+    settings: Option<&ExportSettings>,
+    source: (u32, u32),
 ) -> Result<ExportPaths> {
     fs::create_dir_all(dir).with_context(|| format!("create {}", dir.display()))?;
     let stem = format!(
@@ -262,7 +413,7 @@ pub fn write_exports(
         write_height_png(hpath, plane)?;
     }
     write_svg(&svg, plane)?;
-    write_json(&json, plane, cutter, grid, stamp)?;
+    write_json(&json, plane, cutter, grid, stamp, settings, source)?;
 
     Ok(ExportPaths {
         png,
@@ -371,6 +522,8 @@ fn write_json(
     cutter: &Cutter,
     grid: (u32, u32, u32),
     stamp: &str,
+    settings: Option<&ExportSettings>,
+    source: (u32, u32),
 ) -> Result<()> {
     let stats = plane_stats(plane);
     let max_b = stats.max.max(1e-6);
@@ -383,6 +536,10 @@ fn write_json(
         plane.volume_samples.clone()
     } else {
         Vec::new()
+    };
+    let (export_aspect, export_fit, export_preset) = match settings {
+        Some(s) => (s.aspect.as_str(), s.fit.as_str(), s.square_size()),
+        None => ("native", "pad", 0),
     };
     let doc = SliceJson {
         format: "pycelium-slice-v1",
@@ -406,6 +563,11 @@ fn write_json(
         },
         heightmap_axis: cutter.heightmap_axis.as_str(),
         heightmap: cutter.export_heightmap,
+        export_aspect,
+        export_fit,
+        export_preset,
+        source_width: source.0,
+        source_height: source.1,
         stats,
         density_encoding: "u8_row_major",
         density_u8,
@@ -668,5 +830,92 @@ mod tests {
         let s = plane_stats(&plane);
         assert_eq!(s.occupied, 1);
         assert!(s.max >= 0.3);
+    }
+
+    #[test]
+    fn default_layout_is_512_square() {
+        let vol = brick(8, 6, 4, (2, 3, 1), 1.0);
+        let mut c = Cutter::new(4);
+        c.enter(1.0, 4);
+        c.axis = Axis::Z;
+        c.pos = 0.25;
+        let plane = extract_slice(&vol, &c, false);
+        assert_eq!((plane.width, plane.height), (8, 6));
+        let out = apply_export_layout(&plane, &ExportSettings::default());
+        assert_eq!((out.width, out.height), (512, 512));
+        let i = (256 * 512 + 256) as usize;
+        // Marked voxel (2,3) maps near the center of an 8×6 letterbox.
+        assert!(out.biomass.iter().any(|&b| b > 0.2), "hypha should survive upsample");
+        assert!(out.biomass[i] < 1.5);
+    }
+
+    #[test]
+    fn native_aspect_keeps_slab_size() {
+        let vol = brick(8, 6, 4, (2, 1, 1), 1.0);
+        let mut c = Cutter::new(4);
+        c.enter(1.0, 4);
+        c.axis = Axis::Z;
+        c.pos = 0.25;
+        let plane = extract_slice(&vol, &c, false);
+        let mut settings = ExportSettings::default();
+        settings.aspect = ExportAspect::Native;
+        let out = apply_export_layout(&plane, &settings);
+        assert_eq!((out.width, out.height), (8, 6));
+    }
+
+    #[test]
+    fn crop_aabb_then_square_pads_occupied_region() {
+        let vol = brick(16, 16, 4, (2, 2, 1), 1.0);
+        let mut c = Cutter::new(4);
+        c.enter(1.0, 4);
+        c.axis = Axis::Z;
+        c.pos = 0.25;
+        let plane = extract_slice(&vol, &c, false);
+        let mut settings = ExportSettings::default();
+        settings.fit = FitMode::CropAabb;
+        settings.preset_index = 2; // 32×32
+        let out = apply_export_layout(&plane, &settings);
+        assert_eq!((out.width, out.height), (32, 32));
+        let occupied = out.biomass.iter().filter(|b| **b > 0.2).count();
+        assert!(occupied > 0);
+        // Crop should fill more of the canvas than padding the whole 16×16.
+        settings.fit = FitMode::Pad;
+        let padded = apply_export_layout(&plane, &settings);
+        let pad_occ = padded.biomass.iter().filter(|b| **b > 0.2).count();
+        assert!(occupied >= pad_occ);
+    }
+
+    #[test]
+    fn write_bundle_records_export_meta() {
+        let dir = std::env::temp_dir().join(format!(
+            "pycelium-slice-meta-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        let vol = brick(8, 8, 4, (2, 3, 1), 1.0);
+        let mut c = Cutter::new(4);
+        c.enter(1.0, 4);
+        c.pos = 0.25;
+        let plane = extract_slice(&vol, &c, false);
+        let settings = ExportSettings::default();
+        let composed = apply_export_layout(&plane, &settings);
+        let paths = write_exports_with_meta(
+            &dir,
+            &composed,
+            &c,
+            (8, 8, 4),
+            "20260102_030405",
+            Some(&settings),
+            (plane.width, plane.height),
+        )
+        .unwrap();
+        let (pw, ph) = png_size(&paths.png).unwrap();
+        assert_eq!((pw, ph), (512, 512));
+        let json = fs::read_to_string(&paths.json).unwrap();
+        assert!(json.contains("\"export_aspect\": \"square\""));
+        assert!(json.contains("\"export_fit\": \"pad\""));
+        assert!(json.contains("\"export_preset\": 512"));
+        assert!(json.contains("\"source_width\": 8"));
+        let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/pycelium-win/src/export_settings.rs
+++ b/pycelium-win/src/export_settings.rs
@@ -1,0 +1,315 @@
+//! Export settings window: square power-of-two presets, pad vs crop, native aspect.
+//!
+//! Drawn as an in-engine card on the right (below the slab inset) while capturing.
+//! Geometry here must match `shaders/present.wgsl`.
+
+/// Square power-of-two export sizes, 8 through 8K.
+pub const SQUARE_PRESETS: [u32; 11] = [
+    8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192,
+];
+
+/// Mid-list default: 512², not the native slab aspect.
+pub const DEFAULT_PRESET_INDEX: usize = 6;
+
+/// Right-column card. Sits under the inset (`x=0.72..0.98`, `y=0.06..0.34`)
+/// and above the thickness slider (`y=0.90`).
+pub const PANEL_X0: f32 = 0.735;
+pub const PANEL_X1: f32 = 0.985;
+pub const CHIP_Y0: f32 = 0.368;
+pub const CHIP_Y1: f32 = 0.418;
+pub const PANEL_Y1: f32 = 0.882;
+pub const PRESET_Y0: f32 = 0.448;
+pub const PRESET_ROW: f32 = 0.028;
+pub const FIT_Y0: f32 = 0.768;
+pub const FIT_Y1: f32 = 0.808;
+pub const ASPECT_Y0: f32 = 0.816;
+pub const ASPECT_Y1: f32 = 0.856;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExportAspect {
+    /// Power-of-two square (default).
+    Square,
+    /// Keep the extracted slab aspect (advanced / old behavior).
+    Native,
+}
+
+impl ExportAspect {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Square => "square",
+            Self::Native => "native",
+        }
+    }
+
+    pub fn cycle(self) -> Self {
+        match self {
+            Self::Square => Self::Native,
+            Self::Native => Self::Square,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FitMode {
+    /// Letterbox / pillarbox the full plane into the square.
+    Pad,
+    /// Crop to the occupied density AABB, then letterbox that into the square.
+    CropAabb,
+}
+
+impl FitMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pad => "pad",
+            Self::CropAabb => "crop",
+        }
+    }
+
+    pub fn cycle(self) -> Self {
+        match self {
+            Self::Pad => Self::CropAabb,
+            Self::CropAabb => Self::Pad,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExportHit {
+    TogglePanel,
+    Preset(usize),
+    Fit(FitMode),
+    Aspect(ExportAspect),
+}
+
+#[derive(Clone, Debug)]
+pub struct ExportSettings {
+    pub panel_open: bool,
+    pub aspect: ExportAspect,
+    pub preset_index: usize,
+    pub fit: FitMode,
+}
+
+impl Default for ExportSettings {
+    fn default() -> Self {
+        Self {
+            panel_open: false,
+            aspect: ExportAspect::Square,
+            preset_index: DEFAULT_PRESET_INDEX,
+            fit: FitMode::Pad,
+        }
+    }
+}
+
+impl ExportSettings {
+    pub fn square_size(&self) -> u32 {
+        SQUARE_PRESETS[self.preset_index.min(SQUARE_PRESETS.len() - 1)]
+    }
+
+    pub fn cycle_preset(&mut self, dir: i32) {
+        let n = SQUARE_PRESETS.len() as i32;
+        let next = (self.preset_index as i32 + dir).rem_euclid(n);
+        self.preset_index = next as usize;
+    }
+
+    pub fn set_preset(&mut self, index: usize) {
+        if index < SQUARE_PRESETS.len() {
+            self.preset_index = index;
+        }
+    }
+
+    pub fn toggle_panel(&mut self) {
+        self.panel_open = !self.panel_open;
+    }
+
+    pub fn close_panel(&mut self) {
+        self.panel_open = false;
+    }
+
+    pub fn describe(&self) -> String {
+        if self.aspect == ExportAspect::Native {
+            format!(
+                "native {}  {}",
+                self.fit.as_str(),
+                self.square_size()
+            )
+        } else {
+            format!(
+                "{}x{} {}  {}",
+                self.square_size(),
+                self.square_size(),
+                self.aspect.as_str(),
+                self.fit.as_str()
+            )
+        }
+    }
+
+    /// Packed present uniform: x = open, y = preset index, z = aspect, w = fit.
+    pub fn present_vec(&self) -> [f32; 4] {
+        [
+            if self.panel_open { 1.0 } else { 0.0 },
+            self.preset_index as f32,
+            if self.aspect == ExportAspect::Native {
+                1.0
+            } else {
+                0.0
+            },
+            if self.fit == FitMode::CropAabb {
+                1.0
+            } else {
+                0.0
+            },
+        ]
+    }
+
+    pub fn contains_cursor(&self, uv: (f32, f32)) -> bool {
+        if uv.0 < PANEL_X0 || uv.0 > PANEL_X1 {
+            return false;
+        }
+        if self.panel_open {
+            uv.1 >= CHIP_Y0 && uv.1 <= PANEL_Y1
+        } else {
+            uv.1 >= CHIP_Y0 && uv.1 <= CHIP_Y1
+        }
+    }
+
+    pub fn hit(&self, uv: (f32, f32)) -> Option<ExportHit> {
+        if uv.0 < PANEL_X0 || uv.0 > PANEL_X1 {
+            return None;
+        }
+        if uv.1 >= CHIP_Y0 && uv.1 <= CHIP_Y1 {
+            return Some(ExportHit::TogglePanel);
+        }
+        if !self.panel_open {
+            return None;
+        }
+        if uv.1 >= PRESET_Y0 && uv.1 < PRESET_Y0 + PRESET_ROW * SQUARE_PRESETS.len() as f32 {
+            let i = ((uv.1 - PRESET_Y0) / PRESET_ROW).floor() as i32;
+            if (0..SQUARE_PRESETS.len() as i32).contains(&i) {
+                return Some(ExportHit::Preset(i as usize));
+            }
+        }
+        let mid = 0.5 * (PANEL_X0 + PANEL_X1);
+        if uv.1 >= FIT_Y0 && uv.1 <= FIT_Y1 {
+            return Some(if uv.0 < mid {
+                ExportHit::Fit(FitMode::Pad)
+            } else {
+                ExportHit::Fit(FitMode::CropAabb)
+            });
+        }
+        if uv.1 >= ASPECT_Y0 && uv.1 <= ASPECT_Y1 {
+            return Some(if uv.0 < mid {
+                ExportHit::Aspect(ExportAspect::Square)
+            } else {
+                ExportHit::Aspect(ExportAspect::Native)
+            });
+        }
+        None
+    }
+
+    pub fn apply_hit(&mut self, hit: ExportHit) {
+        match hit {
+            ExportHit::TogglePanel => self.toggle_panel(),
+            ExportHit::Preset(i) => self.set_preset(i),
+            ExportHit::Fit(fit) => self.fit = fit,
+            ExportHit::Aspect(aspect) => self.aspect = aspect,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_512_square_pad() {
+        let s = ExportSettings::default();
+        assert_eq!(s.square_size(), 512);
+        assert_eq!(s.aspect, ExportAspect::Square);
+        assert_eq!(s.fit, FitMode::Pad);
+        assert!(!s.panel_open);
+        assert_eq!(SQUARE_PRESETS[s.preset_index], 512);
+    }
+
+    #[test]
+    fn presets_are_power_of_two_through_8k() {
+        assert_eq!(SQUARE_PRESETS[0], 8);
+        assert_eq!(SQUARE_PRESETS[10], 8192);
+        for (i, &n) in SQUARE_PRESETS.iter().enumerate() {
+            assert_eq!(n, 8u32 << i, "preset {i} should be 8<<{i}");
+        }
+    }
+
+    #[test]
+    fn cycle_preset_wraps() {
+        let mut s = ExportSettings::default();
+        s.cycle_preset(-1);
+        assert_eq!(s.square_size(), 256);
+        s.preset_index = 0;
+        s.cycle_preset(-1);
+        assert_eq!(s.square_size(), 8192);
+        s.cycle_preset(1);
+        assert_eq!(s.square_size(), 8);
+    }
+
+    #[test]
+    fn closed_chip_toggles_panel() {
+        let s = ExportSettings::default();
+        assert_eq!(
+            s.hit((0.86, 0.39)),
+            Some(ExportHit::TogglePanel)
+        );
+        assert!(s.hit((0.86, 0.50)).is_none());
+        assert!(s.contains_cursor((0.86, 0.39)));
+        assert!(!s.contains_cursor((0.86, 0.50)));
+        assert!(!s.contains_cursor((0.40, 0.39)));
+    }
+
+    #[test]
+    fn open_panel_hits_presets_fit_and_aspect() {
+        let mut s = ExportSettings::default();
+        s.panel_open = true;
+        assert_eq!(s.hit((0.86, PRESET_Y0 + 0.01)), Some(ExportHit::Preset(0)));
+        let y512 = PRESET_Y0 + PRESET_ROW * 6.0 + 0.01;
+        assert_eq!(s.hit((0.86, y512)), Some(ExportHit::Preset(6)));
+        let y8k = PRESET_Y0 + PRESET_ROW * 10.0 + 0.01;
+        assert_eq!(s.hit((0.86, y8k)), Some(ExportHit::Preset(10)));
+        assert_eq!(s.hit((0.76, 0.788)), Some(ExportHit::Fit(FitMode::Pad)));
+        assert_eq!(
+            s.hit((0.92, 0.788)),
+            Some(ExportHit::Fit(FitMode::CropAabb))
+        );
+        assert_eq!(
+            s.hit((0.76, 0.836)),
+            Some(ExportHit::Aspect(ExportAspect::Square))
+        );
+        assert_eq!(
+            s.hit((0.92, 0.836)),
+            Some(ExportHit::Aspect(ExportAspect::Native))
+        );
+        assert!(s.contains_cursor((0.86, 0.70)));
+    }
+
+    #[test]
+    fn apply_hit_updates_state() {
+        let mut s = ExportSettings::default();
+        s.apply_hit(ExportHit::Preset(10));
+        assert_eq!(s.square_size(), 8192);
+        s.apply_hit(ExportHit::Fit(FitMode::CropAabb));
+        assert_eq!(s.fit, FitMode::CropAabb);
+        s.apply_hit(ExportHit::Aspect(ExportAspect::Native));
+        assert_eq!(s.aspect, ExportAspect::Native);
+        s.apply_hit(ExportHit::TogglePanel);
+        assert!(s.panel_open);
+    }
+
+    #[test]
+    fn present_vec_packs_flags() {
+        let mut s = ExportSettings::default();
+        assert_eq!(s.present_vec(), [0.0, 6.0, 0.0, 0.0]);
+        s.panel_open = true;
+        s.aspect = ExportAspect::Native;
+        s.fit = FitMode::CropAabb;
+        s.preset_index = 3;
+        assert_eq!(s.present_vec(), [1.0, 3.0, 1.0, 1.0]);
+    }
+}

--- a/pycelium-win/src/gpu.rs
+++ b/pycelium-win/src/gpu.rs
@@ -454,6 +454,7 @@ impl MyceliumGpu {
         label_fade: f32,
         has_picked: bool,
         cutter: [f32; 4],
+        export_ui: [f32; 4],
     ) {
         let present = PresentUniforms {
             width: self.width,
@@ -488,6 +489,7 @@ impl MyceliumGpu {
             slice_oy: self.slice.oy,
             hud_ui: [cursor[0], cursor[1], label_density, label_fade],
             cutter,
+            export_ui,
         };
         queue.write_buffer(&self.present_buf, 0, bytemuck::bytes_of(&present));
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {

--- a/pycelium-win/src/main.rs
+++ b/pycelium-win/src/main.rs
@@ -1,6 +1,7 @@
 mod config;
 mod cutter;
 mod export;
+mod export_settings;
 mod gpu;
 mod hud_font;
 mod memory;
@@ -22,7 +23,8 @@ use winit::window::{Window, WindowId};
 
 use crate::config::{Args, LabelDensity, MemoryPlan};
 use crate::cutter::Cutter;
-use crate::export::{extract_slice, utc_stamp, write_exports};
+use crate::export::{apply_export_layout, extract_slice, utc_stamp, write_exports_with_meta};
+use crate::export_settings::ExportSettings;
 use crate::gpu::{GpuDevice, MyceliumGpu};
 use crate::memory::HostWorld;
 use crate::types::SimUniforms;
@@ -72,6 +74,7 @@ struct Runtime {
     labels: LabelDensity,
     label_fade: f32,
     cutter: Cutter,
+    export: ExportSettings,
     export_dir: PathBuf,
 }
 
@@ -223,6 +226,7 @@ impl ApplicationHandler<AppAction> for App {
                 labels,
                 label_fade: if labels == LabelDensity::Off { 0.0 } else { 1.0 },
                 cutter: Cutter::new(cutter_depth),
+                export: ExportSettings::default(),
                 export_dir,
             })));
         });
@@ -248,7 +252,7 @@ impl ApplicationHandler<AppAction> for App {
                     self.runtime.as_ref().map(|r| r.labels.as_str()).unwrap_or("rich")
                 );
                 println!(
-                    "E capture | C 2D/rich | hover cube face to snap | drag slider handles | Enter export | Esc leave"
+                    "E capture | C 2D/rich | S export settings | hover cube face to snap | drag slider handles | Enter export | Esc leave"
                 );
                 println!(
                     "HUD: FPS, tips, fusions, branches, C:N | bars | then slice Z / thickness / zoom% | selected tip"
@@ -291,7 +295,7 @@ impl ApplicationHandler<AppAction> for App {
                         as f32;
                     if rt.cutter.dragging.is_some() {
                         rt.cutter.drag_handle(rt.cursor, axis_n);
-                    } else if !rt.orbit.dragging {
+                    } else if !rt.orbit.dragging && !rt.export.contains_cursor(rt.cursor) {
                         let (eye, target) = rt.orbit.eye_target();
                         let rd = click_dir(
                             rt.cursor,
@@ -307,6 +311,16 @@ impl ApplicationHandler<AppAction> for App {
             WindowEvent::MouseInput { state, button, .. } => {
                 if button == MouseButton::Left {
                     if state == ElementState::Pressed && rt.cutter.active {
+                        if rt.export.contains_cursor(rt.cursor) {
+                            if let Some(hit) = rt.export.hit(rt.cursor) {
+                                rt.export.apply_hit(hit);
+                                println!("{}", rt.export.describe());
+                            }
+                            rt.orbit.dragging = false;
+                            rt.orbit.last = None;
+                            rt.window.request_redraw();
+                            return;
+                        }
                         let axis_n = rt.cutter.axis.size(rt.sim.width, rt.sim.height, rt.sim.depth)
                             as f32;
                         if let Some(handle) = rt.cutter.hit_handle(rt.cursor, axis_n) {
@@ -334,7 +348,11 @@ impl ApplicationHandler<AppAction> for App {
                     MouseScrollDelta::LineDelta(_, y) => y,
                     MouseScrollDelta::PixelDelta(p) => p.y as f32 / 80.0,
                 };
-                if rt.cutter.active && rt.shift {
+                if rt.cutter.active && rt.export.contains_cursor(rt.cursor) {
+                    rt.export.cycle_preset(if steps > 0.0 { 1 } else { -1 });
+                    println!("{}", rt.export.describe());
+                    rt.window.request_redraw();
+                } else if rt.cutter.active && rt.shift {
                     let axis_n = rt.cutter.axis.size(rt.sim.width, rt.sim.height, rt.sim.depth)
                         as f32;
                     rt.cutter.nudge_half(steps * if rt.shift { 2.0 } else { 1.0 }, axis_n);
@@ -420,8 +438,13 @@ impl ApplicationHandler<AppAction> for App {
                 }
                 match logical_key {
                     Key::Named(NamedKey::Escape) => {
-                        if rt.cutter.active {
+                        if rt.cutter.active && rt.export.panel_open {
+                            rt.export.close_panel();
+                            println!("export settings closed");
+                            rt.window.request_redraw();
+                        } else if rt.cutter.active {
                             rt.cutter.leave();
+                            rt.export.close_panel();
                             println!("capture off");
                             rt.window.request_redraw();
                         } else {
@@ -444,12 +467,33 @@ impl ApplicationHandler<AppAction> for App {
                         rt.cutter.toggle(rt.sim.slice.z, rt.sim.depth);
                         if rt.cutter.active {
                             println!("{}", rt.cutter.describe());
+                            println!("{}", rt.export.describe());
                             println!(
-                                "C cycle 2D/rich | X axis | hover face center/mid-edge to snap | H heightmap | Y height axis | Shift+wheel thickness"
+                                "C cycle 2D/rich | S settings | X axis | hover face center/mid-edge to snap | H heightmap | Y height axis | Shift+wheel thickness"
                             );
                         } else {
+                            rt.export.close_panel();
                             println!("capture off");
                         }
+                        rt.window.request_redraw();
+                    }
+                    Key::Character(c) if c.eq_ignore_ascii_case("s") && rt.cutter.active => {
+                        rt.export.toggle_panel();
+                        println!(
+                            "export settings {}  {}",
+                            if rt.export.panel_open { "open" } else { "closed" },
+                            rt.export.describe()
+                        );
+                        rt.window.request_redraw();
+                    }
+                    Key::Character(c) if c.eq_ignore_ascii_case("p") && rt.cutter.active => {
+                        rt.export.fit = rt.export.fit.cycle();
+                        println!("{}", rt.export.describe());
+                        rt.window.request_redraw();
+                    }
+                    Key::Character(c) if c.eq_ignore_ascii_case("a") && rt.cutter.active => {
+                        rt.export.aspect = rt.export.aspect.cycle();
+                        println!("{}", rt.export.describe());
                         rt.window.request_redraw();
                     }
                     Key::Character(c) if c.eq_ignore_ascii_case("c") && rt.cutter.active => {
@@ -547,8 +591,9 @@ impl ApplicationHandler<AppAction> for App {
                         }
                         if rt.cutter.active {
                             rt.window.set_title(&format!(
-                                "Pycelium 3D | {}",
-                                rt.cutter.describe()
+                                "Pycelium 3D | {}  {}",
+                                rt.cutter.describe(),
+                                rt.export.describe()
                             ));
                         }
                         rt.sim.render(
@@ -565,6 +610,7 @@ impl ApplicationHandler<AppAction> for App {
                             rt.label_fade,
                             rt.has_picked,
                             rt.cutter.present_vec(),
+                            rt.export.present_vec(),
                         );
                         rt.window.pre_present_notify();
                         rt.gpu.queue.present(frame);
@@ -614,20 +660,24 @@ fn export_slice(rt: &Runtime) -> anyhow::Result<()> {
         .sim
         .read_volume_fields(&rt.gpu.device, &rt.gpu.queue)?;
     let plane = extract_slice(&vol, &rt.cutter, rt.cutter.mode == crate::cutter::CaptureMode::RichBox);
+    let composed = apply_export_layout(&plane, &rt.export);
     let stamp = utc_stamp(SystemTime::now());
-    let paths = write_exports(
+    let paths = write_exports_with_meta(
         &rt.export_dir,
-        &plane,
+        &composed,
         &rt.cutter,
         (rt.sim.width, rt.sim.height, rt.sim.depth),
         &stamp,
+        Some(&rt.export),
+        (plane.width, plane.height),
     )?;
     println!(
-        "exported {}  {}  {}  {}",
+        "exported {}  {}  {}×{}  {}",
         paths.png.display(),
-        paths.json.display(),
-        paths.svg.display(),
-        paths.mask.display()
+        rt.export.describe(),
+        composed.width,
+        composed.height,
+        paths.json.display()
     );
     if let Some(h) = paths.height {
         println!("heightmap {}", h.display());

--- a/pycelium-win/src/shaders/present.wgsl
+++ b/pycelium-win/src/shaders/present.wgsl
@@ -42,6 +42,7 @@ struct PresentUniforms {
     slice_oy: f32,
     hud_ui: vec4<f32>,
     cutter: vec4<f32>,
+    export_ui: vec4<f32>,
 }
 
 @group(0) @binding(0) var<uniform> u: PresentUniforms;
@@ -118,6 +119,23 @@ fn digit(cell: vec2<f32>, n: i32) -> f32 {
     }
     let bit = u32(p.y * 3 + p.x);
     return f32((bits >> bit) & 1u);
+}
+
+fn draw_number_trim(uv: vec2<f32>, origin: vec2<f32>, value: f32, digits: i32) -> f32 {
+    let local = (uv - origin) / vec2<f32>(0.0082 * f32(digits), 0.016);
+    if local.x < 0.0 || local.x > 1.0 || local.y < 0.0 || local.y > 1.0 {
+        return 0.0;
+    }
+    let n = max(i32(value), 0);
+    let slot = i32(floor(local.x * f32(digits)));
+    let cell = vec2<f32>(fract(local.x * f32(digits)), local.y);
+    var div = 1;
+    for (var i = 0; i < digits - slot - 1; i++) { div = div * 10; }
+    let d = (n / div) % 10;
+    if d == 0 && n < div && slot < digits - 1 {
+        return 0.0;
+    }
+    return digit(cell, d);
 }
 
 fn draw_number(uv: vec2<f32>, origin: vec2<f32>, value: f32, digits: i32) -> f32 {
@@ -220,6 +238,42 @@ fn label_char(id: i32, slot: i32) -> i32 {
         }
         case 18: { // PARAM
             switch slot { case 0: { return 16; } case 1: { return 1; } case 2: { return 18; } case 3: { return 1; } case 4: { return 13; } default: { return -1; } }
+        }
+        case 19: { // EXPORT
+            switch slot { case 0: { return 5; } case 1: { return 24; } case 2: { return 16; } case 3: { return 15; } case 4: { return 18; } case 5: { return 20; } default: { return -1; } }
+        }
+        case 20: { // SIZE
+            switch slot { case 0: { return 19; } case 1: { return 9; } case 2: { return 26; } case 3: { return 5; } default: { return -1; } }
+        }
+        case 21: { // FIT
+            switch slot { case 0: { return 6; } case 1: { return 9; } case 2: { return 20; } default: { return -1; } }
+        }
+        case 22: { // PAD
+            switch slot { case 0: { return 16; } case 1: { return 1; } case 2: { return 4; } default: { return -1; } }
+        }
+        case 23: { // CROP
+            switch slot { case 0: { return 3; } case 1: { return 18; } case 2: { return 15; } case 3: { return 16; } default: { return -1; } }
+        }
+        case 24: { // ASPECT
+            switch slot { case 0: { return 1; } case 1: { return 19; } case 2: { return 16; } case 3: { return 5; } case 4: { return 3; } case 5: { return 20; } default: { return -1; } }
+        }
+        case 25: { // SQUARE
+            switch slot { case 0: { return 19; } case 1: { return 17; } case 2: { return 21; } case 3: { return 1; } case 4: { return 18; } case 5: { return 5; } default: { return -1; } }
+        }
+        case 26: { // NATIVE
+            switch slot { case 0: { return 14; } case 1: { return 1; } case 2: { return 20; } case 3: { return 9; } case 4: { return 22; } case 5: { return 5; } default: { return -1; } }
+        }
+        case 27: { // PNG
+            switch slot { case 0: { return 16; } case 1: { return 14; } case 2: { return 7; } default: { return -1; } }
+        }
+        case 28: { // MASK
+            switch slot { case 0: { return 13; } case 1: { return 1; } case 2: { return 19; } case 3: { return 11; } default: { return -1; } }
+        }
+        case 29: { // JSON
+            switch slot { case 0: { return 10; } case 1: { return 19; } case 2: { return 15; } case 3: { return 14; } default: { return -1; } }
+        }
+        case 30: { // SVG
+            switch slot { case 0: { return 19; } case 1: { return 22; } case 2: { return 7; } default: { return -1; } }
         }
         default: { return -1; }
     }
@@ -429,6 +483,76 @@ fn fs_main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
             }
             let frame = step(min(min((uv.x - (sx0 - 0.008)), (sx1 + 0.008) - uv.x), min(uv.y - sy0, sy1 - uv.y)), 0.002);
             rgb = mix(srgb, vec3<f32>(0.80, 0.78, 0.70), frame);
+        }
+
+        // Export settings card. Geometry matches export_settings.rs.
+        let ex0 = 0.735;
+        let ex1 = 0.985;
+        let ey0 = 0.368;
+        let chip1 = 0.418;
+        let ey1 = select(chip1, 0.882, u.export_ui.x >= 0.5);
+        if uv.x >= ex0 && uv.x <= ex1 && uv.y >= ey0 && uv.y <= ey1 {
+            let cursor = u.hud_ui.xy;
+            let hover = cursor.x >= ex0 && cursor.x <= ex1 && cursor.y >= ey0 && cursor.y <= ey1;
+            var card = vec3<f32>(0.045, 0.048, 0.052);
+            if hover {
+                card = vec3<f32>(0.055, 0.058, 0.062);
+            }
+            rgb = mix(rgb, card, 0.88);
+            let frame = thin_frame(uv, vec2<f32>(ex0, ey0), vec2<f32>(ex1, ey1));
+            rgb = mix(rgb, vec3<f32>(0.80, 0.78, 0.70), frame);
+            rgb = paint_label(uv, vec2<f32>(0.742, 0.378), 19, 1.0, rgb);
+            let sizes = array<f32, 11>(8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0, 1024.0, 2048.0, 4096.0, 8192.0);
+            let preset = i32(u.export_ui.y + 0.5);
+            let pidx = clamp(preset, 0, 10);
+            var size_ink = draw_number_trim(uv, vec2<f32>(0.868, 0.382), sizes[pidx], 4);
+            rgb = rgb + vec3<f32>(0.95, 0.72, 0.28) * size_ink;
+            if u.export_ui.x >= 0.5 {
+                rgb = paint_label(uv, vec2<f32>(0.742, 0.424), 20, 0.85, rgb);
+                let row_h = 0.028;
+                let row0 = 0.448;
+                for (var i = 0; i < 11; i++) {
+                    let y0 = row0 + f32(i) * row_h;
+                    let y1 = y0 + row_h;
+                    let sel = i == pidx;
+                    if uv.y >= y0 && uv.y < y1 {
+                        var rowc = select(vec3<f32>(0.06, 0.06, 0.07), vec3<f32>(0.42, 0.20, 0.05), sel);
+                        if cursor.y >= y0 && cursor.y < y1 && cursor.x >= ex0 && cursor.x <= ex1 && !sel {
+                            rowc = vec3<f32>(0.10, 0.10, 0.11);
+                        }
+                        rgb = mix(rgb, rowc, 0.75);
+                    }
+                    var ink = draw_number_trim(uv, vec2<f32>(0.802, y0 + 0.005), sizes[i], 4);
+                    let tint = select(vec3<f32>(0.78, 0.80, 0.76), vec3<f32>(1.0, 0.72, 0.28), sel);
+                    rgb = rgb + tint * ink;
+                }
+                rgb = paint_label(uv, vec2<f32>(0.742, 0.748), 21, 0.8, rgb);
+                let mid = 0.5 * (ex0 + ex1);
+                let fit_crop = u.export_ui.w >= 0.5;
+                let native = u.export_ui.z >= 0.5;
+                if uv.y >= 0.768 && uv.y <= 0.808 {
+                    if uv.x < mid {
+                        rgb = mix(rgb, select(vec3<f32>(0.07, 0.07, 0.08), vec3<f32>(0.42, 0.20, 0.05), !fit_crop), 0.7);
+                    } else {
+                        rgb = mix(rgb, select(vec3<f32>(0.07, 0.07, 0.08), vec3<f32>(0.42, 0.20, 0.05), fit_crop), 0.7);
+                    }
+                }
+                rgb = paint_label(uv, vec2<f32>(0.742, 0.776), 22, select(0.55, 1.0, !fit_crop), rgb);
+                rgb = paint_label(uv, vec2<f32>(0.862, 0.776), 23, select(0.55, 1.0, fit_crop), rgb);
+                if uv.y >= 0.816 && uv.y <= 0.856 {
+                    if uv.x < mid {
+                        rgb = mix(rgb, select(vec3<f32>(0.07, 0.07, 0.08), vec3<f32>(0.42, 0.20, 0.05), !native), 0.7);
+                    } else {
+                        rgb = mix(rgb, select(vec3<f32>(0.07, 0.07, 0.08), vec3<f32>(0.42, 0.20, 0.05), native), 0.7);
+                    }
+                }
+                rgb = paint_label(uv, vec2<f32>(0.742, 0.824), 25, select(0.55, 1.0, !native), rgb);
+                rgb = paint_label(uv, vec2<f32>(0.862, 0.824), 26, select(0.55, 1.0, native), rgb);
+                rgb = paint_label(uv, vec2<f32>(0.742, 0.860), 27, 0.55, rgb);
+                rgb = paint_label(uv, vec2<f32>(0.802, 0.860), 28, 0.55, rgb);
+                rgb = paint_label(uv, vec2<f32>(0.862, 0.860), 29, 0.45, rgb);
+                rgb = paint_label(uv, vec2<f32>(0.922, 0.860), 30, 0.45, rgb);
+            }
         }
     }
 

--- a/pycelium-win/src/types.rs
+++ b/pycelium-win/src/types.rs
@@ -191,6 +191,8 @@ pub struct PresentUniforms {
     /// Capture cutter: x = axis (0/1/2), y = pos 0..1, z = half-thickness voxels,
     /// w = 0 off / 1 squash / 2 rich (+0.5 when face-snapped).
     pub cutter: [f32; 4],
+    /// Export settings card: x = panel open, y = preset index, z = native aspect, w = crop.
+    pub export_ui: [f32; 4],
 }
 
 /// Orthogonal section through the pedon. Depth is the plane; thickness is
@@ -251,6 +253,6 @@ mod tests {
     fn present_uniforms_stay_16_byte_aligned() {
         assert_eq!(std::mem::size_of::<PresentUniforms>() % 16, 0);
         assert!(std::mem::size_of::<PresentUniforms>() >= 176);
-        assert_eq!(std::mem::size_of::<PresentUniforms>(), 11 * 16);
+        assert_eq!(std::mem::size_of::<PresentUniforms>(), 12 * 16);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Slice capture now defaults to a **512×512 power-of-two square** instead of the native slab aspect. An in-engine settings card (right column, under the slab inset) lets you pick size, pad vs crop, and optional native aspect.

## Settings card
Reachable from capture (`E`) via the **EXPORT** chip or **`S`**.

| Control | Default | Notes |
|---------|---------|--------|
| Size | **512×512** | 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192 (8K). Click a row, or wheel over the card. |
| Fit | **Pad** | Letterbox the full plane into the square. **Crop** trims to the occupied density AABB first. |
| Aspect | **Square** | Advanced: **Native** keeps the extracted slab width×height (old behavior). |

Formats unchanged: PNG, density mask, JSON, SVG, optional heightmap (`H` / `Y`).

## Keys (capture only)
- `S` toggle settings card
- `P` pad ↔ crop
- `A` square ↔ native
- `Esc` closes the card first, then leaves capture
- `E` / `C` / `Enter` / orbit / pick / HUD **Tab** are unchanged

JSON records `export_aspect`, `export_fit`, `export_preset`, `source_width`, `source_height`. Docs: [docs/SLICE_EXPORT.md](docs/SLICE_EXPORT.md).

`cargo +stable test -p pycelium-win --locked`: 45 passed (settings hits, 512 default, pad/crop/native layout, PNG/JSON meta, present.wgsl).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa9f32c2-86c1-49c1-b3b1-98f38bfd489e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa9f32c2-86c1-49c1-b3b1-98f38bfd489e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

