### PR TITLE
HUD sliders, live nudge feedback, and a clickable export card

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ python pycelium.py
 
 ### GPU mesocosm (`pycelium-win`)
 
-Windows / wgpu 3D pedon. Left telemetry HUD uses **white sans-serif English** plus a color readout box per row (rich by default; **Tab** cycles rich / sparse / off). **H** toggles a corner control-scheme panel; hover a meter for a teach callout. Small 3×5 digits stay on the right. Legend: [docs/HUD_LEGEND.md](docs/HUD_LEGEND.md). Face-aligned **slice export** (`E` capture, `S` settings, `Enter` write PNG/JSON/SVG) defaults to a **512×512** power-of-two square (presets 8…8192): [docs/SLICE_EXPORT.md](docs/SLICE_EXPORT.md). Heightmap write is **M**.
+Windows / wgpu 3D pedon. Left telemetry HUD uses **white sans-serif English** plus a color readout box per row (rich by default; **Tab** cycles rich / sparse / off). Adjustable meters (**SLICE Z**, **THICK**, **ZOOM**, **PARAM**) have framed sliders; tweak keys show a short toast with the name, value, and binds. **H** toggles a corner control-scheme panel; hover a meter for a teach callout. Small 3×5 digits stay on the right. Legend: [docs/HUD_LEGEND.md](docs/HUD_LEGEND.md). Face-aligned **slice export** (`E` capture, `S` settings, `Enter` write PNG/JSON/SVG) defaults to a **512×512** power-of-two square (presets 8…8192): [docs/SLICE_EXPORT.md](docs/SLICE_EXPORT.md). Heightmap write is **M**.
 
 ```bash
 cargo run -p pycelium-win --release -- --preset demo

--- a/docs/HUD_LEGEND.md
+++ b/docs/HUD_LEGEND.md
@@ -45,11 +45,11 @@ Fill is a strided voxel census (`hud_reduce`, every 4th cell). The box and bar s
 
 | Row | Box | English | Small digits | Meaning |
 |-----|-----|---------|--------------|---------|
-| 0.56 | warm | `SLICE Z` | 4 | orthogonal slab depth (voxels) |
-| 0.60 | warm | `THICK` | 3 | slab thickness |
-| 0.64 | warm | `ZOOM` | 3 | XY field as percent (`zoom * 100`) |
+| 0.56 | warm | `SLICE Z` | 4 | orthogonal slab depth (voxels) + slider |
+| 0.60 | warm | `THICK` | 3 | slab thickness + slider |
+| 0.64 | warm | `ZOOM` | 3 | XY field as percent (`zoom * 100`) + slider |
 
-Keys: `[ ]` depth, `; '` thickness, `, .` zoom, arrows pan. Shift = coarse.
+Keys: `[ ]` depth, `; '` thickness, `, .` zoom, arrows pan. Shift = coarse. Drag the framed track, or use the keys; a near-HUD toast shows the value and the keys while you tweak.
 
 ## Selected tip
 
@@ -68,9 +68,9 @@ After a pick, sparse mode keeps this block readable.
 
 | Row | Box | English | Small digits | Meaning |
 |-----|-----|---------|--------------|---------|
-| 0.90 | ice | `PARAM` | 1 + 4 | slot `1–8` and value × 100 |
+| 0.90 | ice | `PARAM` | 1 + 4 | slot `1–8` and value × 100 + slider |
 
-Slots: chemotropism, nitrotropism, autotropism, persistence, maintenance, enzyme_k, branch_cost, extension. Keys `1–8` select, `-` / `=` nudge.
+Slots: chemotropism, nitrotropism, autotropism, persistence, maintenance, enzyme_k, branch_cost, extension. Keys `1–8` select, `-` / `=` nudge, or drag the framed track. While adjusting, a toast shows **slot / name / old→new** and `1–8 select  -/= nudge`, then fades after a short idle.
 
 Slice **export** (face-aligned 2D squash / rich box) is a separate capture mode (`E`). It does not change these HUD rows. The export settings card (`S`) lives on the **right**, under the slab inset. See [SLICE_EXPORT.md](SLICE_EXPORT.md).
 
@@ -78,7 +78,7 @@ Slice **export** (face-aligned 2D squash / rich box) is a separate capture mode 
 
 **H** opens or hides the corner keybind panel (global, including during capture). Hover any left-HUD meter — FPS through PARAM — or a row on that panel for a verbose plain-English callout (sim meaning, plus terms such as anastomosis, chemotropism, soluble C/N, exoenzyme, cord). The popup sits near the mouse and is tied to the control with a thin white elbow / string (1–2 px shadow, no blur).
 
-Tab `off` still teaches if the cursor is on a color box or bar. If a future chrome piece has no hit box, teach cannot fire for it.
+Tab `off` still teaches if the cursor is on a color box, bar, or slider. Sliders stay drawn in every density mode (same as bars). If a future chrome piece has no hit box, teach cannot fire for it.
 
 Heightmap PNG write in capture is **M**, not H. **Y** still cycles the heightmap axis and turns that write on.
 

--- a/docs/SLICE_EXPORT.md
+++ b/docs/SLICE_EXPORT.md
@@ -36,15 +36,17 @@ Hover a **face mid-edge** to rotate **90° on the free axis** (top-face left/rig
 
 ## Export settings (square POT)
 
-Default bake is a **power-of-two square**, not the ultra-wide native slab. The in-engine settings card sits on the right under the slab inset while capturing. Click the **EXPORT** chip (or press `S`) to open it.
+Default bake is a **power-of-two square**, not the ultra-wide native slab. The in-engine settings card sits on the right under the slab inset while capturing, above the thickness slider. Click the **EXPORT** chip (or press `S`) to open it. Size presets are a **two-column** grid so the full card stays on-screen and every control is inside the hit rect.
 
 | Control | Default | Notes |
 |---------|---------|--------|
-| Size preset | **512×512** | 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, **8192 (8K)**. Click a row, or wheel over the card. |
+| Size preset | **512×512** | 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, **8192 (8K)**. Click a cell, or wheel over the card. |
 | Fit | **Pad** | Letterbox / pillarbox the full plane into the square. **Crop** trims to the occupied density AABB first, then pads. |
 | Aspect | **Square** | Advanced: **Native** keeps the extracted slab width×height (old behavior). Size presets apply only to square. |
+| Formats | PNG MASK JSON SVG on | Click a chip to include or skip that file. At least one file stays armed. |
+| Heightmap | **off** | Click the HEIGHT row, or press `M`. `Y` still picks the axis and turns this on. |
 
-Formats are unchanged: PNG, density mask, JSON, SVG, optional heightmap (`M` / `Y`). The card lists those names; heightmap stays a key toggle.
+PNG, density mask, JSON, SVG, and optional heightmap (`M` / `Y`) are the same files as before; the card toggles are live, not labels.
 
 PNG / mask / SVG / `density_u8` are written at the chosen output size. JSON also records `export_aspect`, `export_fit`, `export_preset`, `source_width`, and `source_height`.
 

--- a/pycelium-win/src/export.rs
+++ b/pycelium-win/src/export.rs
@@ -401,19 +401,35 @@ pub fn write_exports_with_meta(
     let json = dir.join(format!("{stem}.json"));
     let svg = dir.join(format!("{stem}.svg"));
     let mask = dir.join(format!("{stem}_mask.png"));
-    let height = if cutter.export_heightmap {
+    let write_png = settings.map(|s| s.write_png).unwrap_or(true);
+    let write_mask = settings.map(|s| s.write_mask).unwrap_or(true);
+    let write_json = settings.map(|s| s.write_json).unwrap_or(true);
+    let write_svg = settings.map(|s| s.write_svg).unwrap_or(true);
+    let write_height = settings
+        .map(|s| s.write_heightmap)
+        .unwrap_or(cutter.export_heightmap)
+        || cutter.export_heightmap;
+    let height = if write_height {
         Some(dir.join(format!("{stem}_height.png")))
     } else {
         None
     };
 
-    write_density_png(&png, plane)?;
-    write_mask_png(&mask, plane)?;
+    if write_png {
+        write_density_png(&png, plane)?;
+    }
+    if write_mask {
+        write_mask_png(&mask, plane)?;
+    }
     if let Some(ref hpath) = height {
         write_height_png(hpath, plane)?;
     }
-    write_svg(&svg, plane)?;
-    write_json(&json, plane, cutter, grid, stamp, settings, source)?;
+    if write_svg {
+        write_svg(&svg, plane)?;
+    }
+    if write_json {
+        write_json(&json, plane, cutter, grid, stamp, settings, source)?;
+    }
 
     Ok(ExportPaths {
         png,
@@ -916,6 +932,41 @@ mod tests {
         assert!(json.contains("\"export_fit\": \"pad\""));
         assert!(json.contains("\"export_preset\": 512"));
         assert!(json.contains("\"source_width\": 8"));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn format_toggles_skip_unselected_files() {
+        let dir = std::env::temp_dir().join(format!(
+            "pycelium-slice-fmt-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        let vol = brick(8, 8, 4, (2, 3, 1), 1.0);
+        let mut c = Cutter::new(4);
+        c.enter(1.0, 4);
+        c.pos = 0.25;
+        let plane = extract_slice(&vol, &c, false);
+        let mut settings = ExportSettings::default();
+        settings.write_svg = false;
+        settings.write_mask = false;
+        settings.write_heightmap = false;
+        let composed = apply_export_layout(&plane, &settings);
+        let paths = write_exports_with_meta(
+            &dir,
+            &composed,
+            &c,
+            (8, 8, 4),
+            "20260102_030405",
+            Some(&settings),
+            (plane.width, plane.height),
+        )
+        .unwrap();
+        assert!(paths.png.exists());
+        assert!(paths.json.exists());
+        assert!(!paths.svg.exists());
+        assert!(!paths.mask.exists());
+        assert!(paths.height.is_none());
         let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/pycelium-win/src/export.rs
+++ b/pycelium-win/src/export.rs
@@ -401,10 +401,10 @@ pub fn write_exports_with_meta(
     let json = dir.join(format!("{stem}.json"));
     let svg = dir.join(format!("{stem}.svg"));
     let mask = dir.join(format!("{stem}_mask.png"));
-    let write_png = settings.map(|s| s.write_png).unwrap_or(true);
-    let write_mask = settings.map(|s| s.write_mask).unwrap_or(true);
-    let write_json = settings.map(|s| s.write_json).unwrap_or(true);
-    let write_svg = settings.map(|s| s.write_svg).unwrap_or(true);
+    let want_png = settings.map(|s| s.write_png).unwrap_or(true);
+    let want_mask = settings.map(|s| s.write_mask).unwrap_or(true);
+    let want_json = settings.map(|s| s.write_json).unwrap_or(true);
+    let want_svg = settings.map(|s| s.write_svg).unwrap_or(true);
     let write_height = settings
         .map(|s| s.write_heightmap)
         .unwrap_or(cutter.export_heightmap)
@@ -415,19 +415,19 @@ pub fn write_exports_with_meta(
         None
     };
 
-    if write_png {
+    if want_png {
         write_density_png(&png, plane)?;
     }
-    if write_mask {
+    if want_mask {
         write_mask_png(&mask, plane)?;
     }
     if let Some(ref hpath) = height {
         write_height_png(hpath, plane)?;
     }
-    if write_svg {
+    if want_svg {
         write_svg(&svg, plane)?;
     }
-    if write_json {
+    if want_json {
         write_json(&json, plane, cutter, grid, stamp, settings, source)?;
     }
 

--- a/pycelium-win/src/export_settings.rs
+++ b/pycelium-win/src/export_settings.rs
@@ -1,7 +1,12 @@
-//! Export settings window: square power-of-two presets, pad vs crop, native aspect.
+//! Export settings window: square power-of-two presets, pad vs crop, native aspect,
+//! and optional format toggles.
 //!
 //! Drawn as an in-engine card on the right (below the slab inset) while capturing.
 //! Geometry here must match `shaders/present.wgsl`.
+//!
+//! The previous 11-row preset stack plus FIT / ASPECT / format labels overflowed:
+//! FIT sat on the 8K row, and SVG painted past the card / window. Presets are now
+//! two columns so the full card stays above the thickness slider (`y=0.90`).
 
 /// Square power-of-two export sizes, 8 through 8K.
 pub const SQUARE_PRESETS: [u32; 11] = [
@@ -16,14 +21,20 @@ pub const DEFAULT_PRESET_INDEX: usize = 6;
 pub const PANEL_X0: f32 = 0.735;
 pub const PANEL_X1: f32 = 0.985;
 pub const CHIP_Y0: f32 = 0.368;
-pub const CHIP_Y1: f32 = 0.418;
-pub const PANEL_Y1: f32 = 0.882;
-pub const PRESET_Y0: f32 = 0.448;
-pub const PRESET_ROW: f32 = 0.028;
-pub const FIT_Y0: f32 = 0.768;
-pub const FIT_Y1: f32 = 0.808;
-pub const ASPECT_Y0: f32 = 0.816;
-pub const ASPECT_Y1: f32 = 0.856;
+pub const CHIP_Y1: f32 = 0.412;
+pub const PANEL_Y1: f32 = 0.848;
+pub const PRESET_Y0: f32 = 0.440;
+pub const PRESET_ROW: f32 = 0.032;
+pub const PRESET_COLS: usize = 2;
+pub const PRESET_ROWS: usize = 6;
+pub const FIT_Y0: f32 = 0.644;
+pub const FIT_Y1: f32 = 0.684;
+pub const ASPECT_Y0: f32 = 0.692;
+pub const ASPECT_Y1: f32 = 0.732;
+pub const FORMAT_Y0: f32 = 0.748;
+pub const FORMAT_Y1: f32 = 0.788;
+pub const HT_Y0: f32 = 0.796;
+pub const HT_Y1: f32 = 0.836;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ExportAspect {
@@ -74,11 +85,33 @@ impl FitMode {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExportFormat {
+    Png,
+    Mask,
+    Json,
+    Svg,
+    Heightmap,
+}
+
+impl ExportFormat {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Png => "png",
+            Self::Mask => "mask",
+            Self::Json => "json",
+            Self::Svg => "svg",
+            Self::Heightmap => "heightmap",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ExportHit {
     TogglePanel,
     Preset(usize),
     Fit(FitMode),
     Aspect(ExportAspect),
+    Format(ExportFormat),
 }
 
 #[derive(Clone, Debug)]
@@ -87,6 +120,11 @@ pub struct ExportSettings {
     pub aspect: ExportAspect,
     pub preset_index: usize,
     pub fit: FitMode,
+    pub write_png: bool,
+    pub write_mask: bool,
+    pub write_json: bool,
+    pub write_svg: bool,
+    pub write_heightmap: bool,
 }
 
 impl Default for ExportSettings {
@@ -96,6 +134,11 @@ impl Default for ExportSettings {
             aspect: ExportAspect::Square,
             preset_index: DEFAULT_PRESET_INDEX,
             fit: FitMode::Pad,
+            write_png: true,
+            write_mask: true,
+            write_json: true,
+            write_svg: true,
+            write_heightmap: false,
         }
     }
 }
@@ -125,39 +168,101 @@ impl ExportSettings {
         self.panel_open = false;
     }
 
+    pub fn toggle_format(&mut self, format: ExportFormat) {
+        match format {
+            ExportFormat::Png => self.write_png = !self.write_png,
+            ExportFormat::Mask => self.write_mask = !self.write_mask,
+            ExportFormat::Json => self.write_json = !self.write_json,
+            ExportFormat::Svg => self.write_svg = !self.write_svg,
+            ExportFormat::Heightmap => self.write_heightmap = !self.write_heightmap,
+        }
+        // Enter should still write something if the user turns every file off.
+        if !self.write_png
+            && !self.write_mask
+            && !self.write_json
+            && !self.write_svg
+            && !self.write_heightmap
+        {
+            self.write_png = true;
+        }
+    }
+
+    pub fn format_on(&self, format: ExportFormat) -> bool {
+        match format {
+            ExportFormat::Png => self.write_png,
+            ExportFormat::Mask => self.write_mask,
+            ExportFormat::Json => self.write_json,
+            ExportFormat::Svg => self.write_svg,
+            ExportFormat::Heightmap => self.write_heightmap,
+        }
+    }
+
     pub fn describe(&self) -> String {
+        let mut formats = String::new();
+        for (on, name) in [
+            (self.write_png, "png"),
+            (self.write_mask, "mask"),
+            (self.write_json, "json"),
+            (self.write_svg, "svg"),
+            (self.write_heightmap, "height"),
+        ] {
+            if on {
+                if !formats.is_empty() {
+                    formats.push(' ');
+                }
+                formats.push_str(name);
+            }
+        }
         if self.aspect == ExportAspect::Native {
             format!(
-                "native {}  {}",
+                "native {}  {}  {}",
                 self.fit.as_str(),
-                self.square_size()
+                self.square_size(),
+                formats
             )
         } else {
             format!(
-                "{}x{} {}  {}",
+                "{}x{} {}  {}  {}",
                 self.square_size(),
                 self.square_size(),
                 self.aspect.as_str(),
-                self.fit.as_str()
+                self.fit.as_str(),
+                formats
             )
         }
     }
 
-    /// Packed present uniform: x = open, y = preset index, z = aspect, w = fit.
+    /// Packed present uniform: x = open, y = preset index,
+    /// z = flags (bit0 native, bit1 crop, bit2 png, bit3 mask, bit4 json,
+    /// bit5 svg, bit6 heightmap).
     pub fn present_vec(&self) -> [f32; 4] {
+        let mut flags = 0u32;
+        if self.aspect == ExportAspect::Native {
+            flags |= 1;
+        }
+        if self.fit == FitMode::CropAabb {
+            flags |= 2;
+        }
+        if self.write_png {
+            flags |= 4;
+        }
+        if self.write_mask {
+            flags |= 8;
+        }
+        if self.write_json {
+            flags |= 16;
+        }
+        if self.write_svg {
+            flags |= 32;
+        }
+        if self.write_heightmap {
+            flags |= 64;
+        }
         [
             if self.panel_open { 1.0 } else { 0.0 },
             self.preset_index as f32,
-            if self.aspect == ExportAspect::Native {
-                1.0
-            } else {
-                0.0
-            },
-            if self.fit == FitMode::CropAabb {
-                1.0
-            } else {
-                0.0
-            },
+            flags as f32,
+            0.0,
         ]
     }
 
@@ -172,6 +277,41 @@ impl ExportSettings {
         }
     }
 
+    fn preset_index_at(uv: (f32, f32)) -> Option<usize> {
+        let rows = PRESET_ROWS as f32;
+        if uv.1 < PRESET_Y0 || uv.1 >= PRESET_Y0 + PRESET_ROW * rows {
+            return None;
+        }
+        let row = ((uv.1 - PRESET_Y0) / PRESET_ROW).floor() as i32;
+        if !(0..PRESET_ROWS as i32).contains(&row) {
+            return None;
+        }
+        let mid = 0.5 * (PANEL_X0 + PANEL_X1);
+        let col = if uv.0 < mid { 0 } else { 1 };
+        let i = row as usize * PRESET_COLS + col;
+        if i < SQUARE_PRESETS.len() {
+            Some(i)
+        } else {
+            None
+        }
+    }
+
+    fn format_at(uv: (f32, f32)) -> Option<ExportFormat> {
+        if uv.1 >= FORMAT_Y0 && uv.1 <= FORMAT_Y1 {
+            let t = ((uv.0 - PANEL_X0) / (PANEL_X1 - PANEL_X0)).clamp(0.0, 0.999);
+            return Some(match (t * 4.0).floor() as i32 {
+                0 => ExportFormat::Png,
+                1 => ExportFormat::Mask,
+                2 => ExportFormat::Json,
+                _ => ExportFormat::Svg,
+            });
+        }
+        if uv.1 >= HT_Y0 && uv.1 <= HT_Y1 {
+            return Some(ExportFormat::Heightmap);
+        }
+        None
+    }
+
     pub fn hit(&self, uv: (f32, f32)) -> Option<ExportHit> {
         if uv.0 < PANEL_X0 || uv.0 > PANEL_X1 {
             return None;
@@ -182,11 +322,8 @@ impl ExportSettings {
         if !self.panel_open {
             return None;
         }
-        if uv.1 >= PRESET_Y0 && uv.1 < PRESET_Y0 + PRESET_ROW * SQUARE_PRESETS.len() as f32 {
-            let i = ((uv.1 - PRESET_Y0) / PRESET_ROW).floor() as i32;
-            if (0..SQUARE_PRESETS.len() as i32).contains(&i) {
-                return Some(ExportHit::Preset(i as usize));
-            }
+        if let Some(i) = Self::preset_index_at(uv) {
+            return Some(ExportHit::Preset(i));
         }
         let mid = 0.5 * (PANEL_X0 + PANEL_X1);
         if uv.1 >= FIT_Y0 && uv.1 <= FIT_Y1 {
@@ -203,6 +340,9 @@ impl ExportSettings {
                 ExportHit::Aspect(ExportAspect::Native)
             });
         }
+        if let Some(fmt) = Self::format_at(uv) {
+            return Some(ExportHit::Format(fmt));
+        }
         None
     }
 
@@ -212,6 +352,7 @@ impl ExportSettings {
             ExportHit::Preset(i) => self.set_preset(i),
             ExportHit::Fit(fit) => self.fit = fit,
             ExportHit::Aspect(aspect) => self.aspect = aspect,
+            ExportHit::Format(fmt) => self.toggle_format(fmt),
         }
     }
 }
@@ -227,6 +368,8 @@ mod tests {
         assert_eq!(s.aspect, ExportAspect::Square);
         assert_eq!(s.fit, FitMode::Pad);
         assert!(!s.panel_open);
+        assert!(s.write_png && s.write_mask && s.write_json && s.write_svg);
+        assert!(!s.write_heightmap);
         assert_eq!(SQUARE_PRESETS[s.preset_index], 512);
     }
 
@@ -254,10 +397,7 @@ mod tests {
     #[test]
     fn closed_chip_toggles_panel() {
         let s = ExportSettings::default();
-        assert_eq!(
-            s.hit((0.86, 0.39)),
-            Some(ExportHit::TogglePanel)
-        );
+        assert_eq!(s.hit((0.86, 0.39)), Some(ExportHit::TogglePanel));
         assert!(s.hit((0.86, 0.50)).is_none());
         assert!(s.contains_cursor((0.86, 0.39)));
         assert!(!s.contains_cursor((0.86, 0.50)));
@@ -265,28 +405,64 @@ mod tests {
     }
 
     #[test]
-    fn open_panel_hits_presets_fit_and_aspect() {
+    fn open_panel_hits_two_column_presets_fit_aspect_and_formats() {
         let mut s = ExportSettings::default();
         s.panel_open = true;
-        assert_eq!(s.hit((0.86, PRESET_Y0 + 0.01)), Some(ExportHit::Preset(0)));
-        let y512 = PRESET_Y0 + PRESET_ROW * 6.0 + 0.01;
-        assert_eq!(s.hit((0.86, y512)), Some(ExportHit::Preset(6)));
-        let y8k = PRESET_Y0 + PRESET_ROW * 10.0 + 0.01;
-        assert_eq!(s.hit((0.86, y8k)), Some(ExportHit::Preset(10)));
-        assert_eq!(s.hit((0.76, 0.788)), Some(ExportHit::Fit(FitMode::Pad)));
+        // 8 is left cell of row 0; 16 is right cell.
         assert_eq!(
-            s.hit((0.92, 0.788)),
+            s.hit((0.76, PRESET_Y0 + 0.01)),
+            Some(ExportHit::Preset(0))
+        );
+        assert_eq!(
+            s.hit((0.92, PRESET_Y0 + 0.01)),
+            Some(ExportHit::Preset(1))
+        );
+        // 512 is left cell of row 3 (index 6).
+        let y512 = PRESET_Y0 + PRESET_ROW * 3.0 + 0.01;
+        assert_eq!(s.hit((0.76, y512)), Some(ExportHit::Preset(6)));
+        // 8192 is left cell of row 5 (index 10); right cell is empty.
+        let y8k = PRESET_Y0 + PRESET_ROW * 5.0 + 0.01;
+        assert_eq!(s.hit((0.76, y8k)), Some(ExportHit::Preset(10)));
+        assert!(s.hit((0.92, y8k)).is_none());
+        assert_eq!(s.hit((0.76, 0.664)), Some(ExportHit::Fit(FitMode::Pad)));
+        assert_eq!(
+            s.hit((0.92, 0.664)),
             Some(ExportHit::Fit(FitMode::CropAabb))
         );
         assert_eq!(
-            s.hit((0.76, 0.836)),
+            s.hit((0.76, 0.712)),
             Some(ExportHit::Aspect(ExportAspect::Square))
         );
         assert_eq!(
-            s.hit((0.92, 0.836)),
+            s.hit((0.92, 0.712)),
             Some(ExportHit::Aspect(ExportAspect::Native))
         );
+        let span = PANEL_X1 - PANEL_X0;
+        assert_eq!(
+            s.hit((PANEL_X0 + span * 0.12, 0.768)),
+            Some(ExportHit::Format(ExportFormat::Png))
+        );
+        assert_eq!(
+            s.hit((PANEL_X0 + span * 0.38, 0.768)),
+            Some(ExportHit::Format(ExportFormat::Mask))
+        );
+        assert_eq!(
+            s.hit((PANEL_X0 + span * 0.62, 0.768)),
+            Some(ExportHit::Format(ExportFormat::Json))
+        );
+        assert_eq!(
+            s.hit((PANEL_X0 + span * 0.88, 0.768)),
+            Some(ExportHit::Format(ExportFormat::Svg))
+        );
+        assert_eq!(
+            s.hit((0.86, 0.816)),
+            Some(ExportHit::Format(ExportFormat::Heightmap))
+        );
         assert!(s.contains_cursor((0.86, 0.70)));
+        assert!(PANEL_Y1 < 0.90, "card must sit above the thickness slider");
+        assert!(FIT_Y0 >= PRESET_Y0 + PRESET_ROW * PRESET_ROWS as f32);
+        assert!(FORMAT_Y1 <= HT_Y0);
+        assert!(HT_Y1 <= PANEL_Y1);
     }
 
     #[test]
@@ -300,16 +476,34 @@ mod tests {
         assert_eq!(s.aspect, ExportAspect::Native);
         s.apply_hit(ExportHit::TogglePanel);
         assert!(s.panel_open);
+        s.apply_hit(ExportHit::Format(ExportFormat::Svg));
+        assert!(!s.write_svg);
+        s.apply_hit(ExportHit::Format(ExportFormat::Heightmap));
+        assert!(s.write_heightmap);
+    }
+
+    #[test]
+    fn last_format_stays_on() {
+        let mut s = ExportSettings::default();
+        s.write_mask = false;
+        s.write_json = false;
+        s.write_svg = false;
+        s.toggle_format(ExportFormat::Png);
+        assert!(s.write_png, "PNG should snap back on if it was the last file");
     }
 
     #[test]
     fn present_vec_packs_flags() {
         let mut s = ExportSettings::default();
-        assert_eq!(s.present_vec(), [0.0, 6.0, 0.0, 0.0]);
+        // default: square, pad, png+mask+json+svg = bits 2+3+4+5 = 4+8+16+32 = 60
+        assert_eq!(s.present_vec(), [0.0, 6.0, 60.0, 0.0]);
         s.panel_open = true;
         s.aspect = ExportAspect::Native;
         s.fit = FitMode::CropAabb;
         s.preset_index = 3;
-        assert_eq!(s.present_vec(), [1.0, 3.0, 1.0, 1.0]);
+        s.write_heightmap = true;
+        s.write_svg = false;
+        // native+crop+png+mask+json+height = 1+2+4+8+16+64 = 95
+        assert_eq!(s.present_vec(), [1.0, 3.0, 95.0, 0.0]);
     }
 }

--- a/pycelium-win/src/export_settings.rs
+++ b/pycelium-win/src/export_settings.rs
@@ -505,5 +505,8 @@ mod tests {
         s.write_svg = false;
         // native+crop+png+mask+json+height = 1+2+4+8+16+64 = 95
         assert_eq!(s.present_vec(), [1.0, 3.0, 95.0, 0.0]);
+        assert!(s.format_on(ExportFormat::Png));
+        assert!(!s.format_on(ExportFormat::Svg));
+        assert_eq!(ExportFormat::Heightmap.as_str(), "heightmap");
     }
 }

--- a/pycelium-win/src/gpu.rs
+++ b/pycelium-win/src/gpu.rs
@@ -431,6 +431,10 @@ impl MyceliumGpu {
         self.uniforms.adjust(self.param_slot, delta);
     }
 
+    pub fn set_param_normalized(&mut self, t: f32) {
+        self.uniforms.set_normalized(self.param_slot, t);
+    }
+
     pub fn upload_brick(&self, queue: &wgpu::Queue, world: &HostWorld) {
         let brick = world.extract_brick(self.width, self.height, self.depth);
         queue.write_buffer(&self.organic, 0, bytemuck::cast_slice(&brick.organic));
@@ -507,6 +511,7 @@ impl MyceliumGpu {
             help_rect: overlay.help_rect,
             tip_rect: overlay.tip_rect,
             callout: overlay.callout,
+            nudge_rect: overlay.nudge_rect,
         };
         queue.write_buffer(&self.present_buf, 0, bytemuck::bytes_of(&present));
         queue.write_buffer(&self.overlay_buf, 0, bytemuck::cast_slice(&overlay.chars));

--- a/pycelium-win/src/main.rs
+++ b/pycelium-win/src/main.rs
@@ -28,7 +28,7 @@ use crate::export::{apply_export_layout, extract_slice, utc_stamp, write_exports
 use crate::export_settings::ExportSettings;
 use crate::gpu::{GpuDevice, MyceliumGpu};
 use crate::memory::HostWorld;
-use crate::teach::HoverId;
+use crate::teach::{HoverId, HudSlider, NudgeKind, NudgeToast};
 use crate::types::SimUniforms;
 
 enum AppAction {
@@ -82,6 +82,22 @@ struct Runtime {
     scheme_fade: f32,
     tip_fade: f32,
     last_hover: HoverId,
+    nudge: Option<LiveNudge>,
+    hud_drag: Option<HudDrag>,
+}
+
+struct LiveNudge {
+    kind: NudgeKind,
+    title: String,
+    old: String,
+    new: String,
+    last: Instant,
+}
+
+#[derive(Clone)]
+struct HudDrag {
+    slider: HudSlider,
+    start: String,
 }
 
 struct App {
@@ -238,6 +254,8 @@ impl ApplicationHandler<AppAction> for App {
                 scheme_fade: 0.0,
                 tip_fade: 0.0,
                 last_hover: HoverId::None,
+                nudge: None,
+                hud_drag: None,
             })));
         });
     }
@@ -301,12 +319,19 @@ impl ApplicationHandler<AppAction> for App {
                     (x as f32 / rt.config.width as f32).clamp(0.0, 1.0),
                     (y as f32 / rt.config.height as f32).clamp(0.0, 1.0),
                 );
+                if let Some(drag) = rt.hud_drag.clone() {
+                    apply_hud_slider(rt, drag.slider, rt.cursor.0, &drag.start);
+                    rt.window.request_redraw();
+                }
                 if rt.cutter.active {
                     let axis_n = rt.cutter.axis.size(rt.sim.width, rt.sim.height, rt.sim.depth)
                         as f32;
                     if rt.cutter.dragging.is_some() {
                         rt.cutter.drag_handle(rt.cursor, axis_n);
-                    } else if !rt.orbit.dragging && !rt.export.contains_cursor(rt.cursor) {
+                    } else if !rt.orbit.dragging
+                        && rt.hud_drag.is_none()
+                        && !rt.export.contains_cursor(rt.cursor)
+                    {
                         let (eye, target) = rt.orbit.eye_target();
                         let rd = click_dir(
                             rt.cursor,
@@ -327,10 +352,69 @@ impl ApplicationHandler<AppAction> for App {
                         rt.orbit.last = None;
                         return;
                     }
+                    if state == ElementState::Pressed {
+                        if let Some(slider) = teach::hud_slider_at(rt.cursor) {
+                            let start = match slider {
+                                HudSlider::SliceZ => fmt_slice_z(rt.sim.slice.z),
+                                HudSlider::Thick => fmt_thick(rt.sim.slice.thickness),
+                                HudSlider::Zoom => fmt_zoom(rt.sim.slice.zoom),
+                                HudSlider::Param => fmt_param(
+                                    rt.sim.param_slot,
+                                    rt.sim.uniforms.param_value(rt.sim.param_slot),
+                                ),
+                            };
+                            if rt.cursor.0 >= teach::SLIDER_TRACK_X0 {
+                                apply_hud_slider(rt, slider, rt.cursor.0, &start);
+                            } else {
+                                match slider {
+                                    HudSlider::SliceZ => fire_nudge(
+                                        rt,
+                                        NudgeKind::SliceZ,
+                                        "SLICE Z".into(),
+                                        start.clone(),
+                                        start.clone(),
+                                    ),
+                                    HudSlider::Thick => fire_nudge(
+                                        rt,
+                                        NudgeKind::Thick,
+                                        "THICK".into(),
+                                        start.clone(),
+                                        start.clone(),
+                                    ),
+                                    HudSlider::Zoom => fire_nudge(
+                                        rt,
+                                        NudgeKind::Zoom,
+                                        "ZOOM".into(),
+                                        start.clone(),
+                                        start.clone(),
+                                    ),
+                                    HudSlider::Param => fire_nudge(
+                                        rt,
+                                        NudgeKind::Param,
+                                        param_title(rt.sim.param_slot),
+                                        start.clone(),
+                                        start.clone(),
+                                    ),
+                                }
+                            }
+                            rt.hud_drag = Some(HudDrag { slider, start });
+                            rt.orbit.dragging = false;
+                            rt.orbit.last = None;
+                            rt.window.request_redraw();
+                            return;
+                        }
+                    }
+                    if state == ElementState::Released && rt.hud_drag.is_some() {
+                        rt.hud_drag = None;
+                        rt.orbit.dragging = false;
+                        rt.orbit.last = None;
+                        return;
+                    }
                     if state == ElementState::Pressed && rt.cutter.active {
                         if rt.export.contains_cursor(rt.cursor) {
                             if let Some(hit) = rt.export.hit(rt.cursor) {
                                 rt.export.apply_hit(hit);
+                                rt.cutter.export_heightmap = rt.export.write_heightmap;
                                 println!("{}", rt.export.describe());
                             }
                             rt.orbit.dragging = false;
@@ -396,6 +480,10 @@ impl ApplicationHandler<AppAction> for App {
                 }
                 let max_z = rt.sim.depth as f32;
                 let step = if rt.shift { 8.0 } else { 1.0 };
+                let old_z = fmt_slice_z(rt.sim.slice.z);
+                let old_thick = fmt_thick(rt.sim.slice.thickness);
+                let old_zoom = fmt_zoom(rt.sim.slice.zoom);
+                let old_pan = fmt_pan(rt.sim.slice.ox, rt.sim.slice.oy);
                 let slice_key = match &logical_key {
                     Key::Character(c) if c == "[" => {
                         rt.sim.slice.nudge_depth(-step, max_z);
@@ -441,12 +529,53 @@ impl ApplicationHandler<AppAction> for App {
                 };
                 if slice_key {
                     rt.sim.uniforms.slice_z = rt.sim.slice.z;
+                    let (kind, title, old, value) = match &logical_key {
+                        Key::Character(c) if c == "[" || c == "]" => (
+                            NudgeKind::SliceZ,
+                            "SLICE Z".into(),
+                            old_z,
+                            fmt_slice_z(rt.sim.slice.z),
+                        ),
+                        Key::Character(c) if c == ";" || c == "'" => (
+                            NudgeKind::Thick,
+                            "THICK".into(),
+                            old_thick,
+                            fmt_thick(rt.sim.slice.thickness),
+                        ),
+                        Key::Character(c) if c == "," || c == "." => (
+                            NudgeKind::Zoom,
+                            "ZOOM".into(),
+                            old_zoom,
+                            fmt_zoom(rt.sim.slice.zoom),
+                        ),
+                        _ => (
+                            NudgeKind::Pan,
+                            "PAN".into(),
+                            old_pan,
+                            fmt_pan(rt.sim.slice.ox, rt.sim.slice.oy),
+                        ),
+                    };
+                    fire_nudge(rt, kind, title, old, value);
                     rt.window.set_title(&format!(
                         "Pycelium 3D | slice Z {:.0}  thick {:.0}  field {:.0}%",
                         rt.sim.slice.z,
                         rt.sim.slice.thickness,
                         rt.sim.slice.zoom * 100.0
                     ));
+                    rt.window.request_redraw();
+                    return;
+                }
+                let param_nudge = match &logical_key {
+                    Key::Character(c) if c == "-" || c == "_" => Some(-0.04),
+                    Key::Character(c) if c == "=" || c == "+" => Some(0.04),
+                    _ => None,
+                };
+                if let Some(delta) = param_nudge {
+                    let slot = rt.sim.param_slot;
+                    let old = fmt_param(slot, rt.sim.uniforms.param_value(slot));
+                    rt.sim.adjust_param(delta);
+                    let new = fmt_param(slot, rt.sim.uniforms.param_value(slot));
+                    fire_nudge(rt, NudgeKind::Param, param_title(slot), old, new);
                     rt.window.request_redraw();
                     return;
                 }
@@ -532,11 +661,15 @@ impl ApplicationHandler<AppAction> for App {
                         rt.window.request_redraw();
                     }
                     Key::Character(c) if c.eq_ignore_ascii_case("m") && rt.cutter.active => {
-                        rt.cutter.export_heightmap = !rt.cutter.export_heightmap;
+                        rt.export.toggle_format(crate::export_settings::ExportFormat::Heightmap);
+                        rt.cutter.export_heightmap = rt.export.write_heightmap;
                         println!("{}", rt.cutter.describe());
+                        println!("{}", rt.export.describe());
                     }
                     Key::Character(c) if c.eq_ignore_ascii_case("y") && rt.cutter.active => {
                         rt.cutter.cycle_heightmap_axis();
+                        rt.export.write_heightmap = true;
+                        rt.cutter.export_heightmap = true;
                         println!("{}", rt.cutter.describe());
                     }
                     Key::Named(NamedKey::Space) => rt.paused = !rt.paused,
@@ -550,17 +683,27 @@ impl ApplicationHandler<AppAction> for App {
                     Key::Character(c) if c.eq_ignore_ascii_case("d") => {
                         rt.plan.drift = !rt.plan.drift;
                     }
-                    Key::Character(c) if c == "-" || c == "_" => rt.sim.adjust_param(-0.04),
-                    Key::Character(c) if c == "=" || c == "+" => rt.sim.adjust_param(0.04),
                     Key::Character(c) => {
                         if let Some(d) = c.chars().next().and_then(|ch| ch.to_digit(10)) {
                             if (1..=8).contains(&d) {
                                 rt.sim.param_slot = d - 1;
+                                let v = fmt_param(
+                                    rt.sim.param_slot,
+                                    rt.sim.uniforms.param_value(rt.sim.param_slot),
+                                );
+                                fire_nudge(
+                                    rt,
+                                    NudgeKind::Param,
+                                    param_title(rt.sim.param_slot),
+                                    v.clone(),
+                                    v.clone(),
+                                );
                                 println!(
                                     "param {} = {:.4}",
                                     SimUniforms::param_name(rt.sim.param_slot),
                                     rt.sim.uniforms.param_value(rt.sim.param_slot)
                                 );
+                                rt.window.request_redraw();
                             }
                         }
                     }
@@ -646,6 +789,10 @@ impl ApplicationHandler<AppAction> for App {
                         if rt.tip_fade <= 0.01 && hover == HoverId::None {
                             rt.last_hover = HoverId::None;
                         }
+                        let toast = current_nudge(rt);
+                        if toast.is_none() {
+                            rt.nudge = None;
+                        }
                         let overlay = teach::pack_overlay(
                             rt.scheme_visible || rt.scheme_fade > 0.01,
                             rt.export.panel_open,
@@ -659,6 +806,7 @@ impl ApplicationHandler<AppAction> for App {
                             anchor,
                             rt.scheme_fade,
                             rt.tip_fade,
+                            toast.as_ref(),
                         );
                         rt.sim.render(
                             &rt.gpu.device,
@@ -713,7 +861,7 @@ impl ApplicationHandler<AppAction> for App {
 
     fn about_to_wait(&mut self, _event_loop: &ActiveEventLoop) {
         if let Some(rt) = &self.runtime {
-            if !rt.paused {
+            if !rt.paused || rt.nudge.is_some() || rt.scheme_fade > 0.01 || rt.tip_fade > 0.01 {
                 rt.window.request_redraw();
             }
         }
@@ -748,6 +896,120 @@ fn export_slice(rt: &Runtime) -> anyhow::Result<()> {
         println!("heightmap {}", h.display());
     }
     Ok(())
+}
+
+fn fmt_param(slot: u32, value: f32) -> String {
+    match slot % 8 {
+        4 | 5 => format!("{value:.4}"),
+        _ => format!("{value:.2}"),
+    }
+}
+
+fn fmt_slice_z(z: f32) -> String {
+    format!("{z:.0}")
+}
+
+fn fmt_thick(t: f32) -> String {
+    format!("{t:.0}")
+}
+
+fn fmt_zoom(z: f32) -> String {
+    format!("{:.0}", z * 100.0)
+}
+
+fn fmt_pan(ox: f32, oy: f32) -> String {
+    format!("{:.0}  {:.0}", ox * 100.0, oy * 100.0)
+}
+
+fn param_title(slot: u32) -> String {
+    format!(
+        "{} {}",
+        slot % 8 + 1,
+        SimUniforms::param_name(slot).replace('_', " ")
+    )
+}
+
+fn fire_nudge(rt: &mut Runtime, kind: NudgeKind, title: String, old: String, new: String) {
+    rt.nudge = Some(LiveNudge {
+        kind,
+        title,
+        old,
+        new,
+        last: Instant::now(),
+    });
+}
+
+fn current_nudge(rt: &Runtime) -> Option<NudgeToast> {
+    let n = rt.nudge.as_ref()?;
+    let idle = n.last.elapsed().as_secs_f32();
+    let fade = if idle < 1.15 {
+        1.0
+    } else {
+        (1.0 - (idle - 1.15) / 0.45).clamp(0.0, 1.0)
+    };
+    if fade <= 0.004 {
+        return None;
+    }
+    let value = if n.old == n.new {
+        n.new.clone()
+    } else {
+        format!("{} TO {}", n.old, n.new)
+    };
+    Some(NudgeToast {
+        kind: n.kind,
+        title: n.title.to_ascii_uppercase(),
+        value,
+        keys: n.kind.keys().to_string(),
+        fade,
+    })
+}
+
+fn apply_hud_slider(rt: &mut Runtime, slider: HudSlider, x: f32, start: &str) {
+    let t = teach::slider_t(x);
+    let max_z = rt.sim.depth as f32;
+    match slider {
+        HudSlider::SliceZ => {
+            rt.sim.slice.set_depth_normalized(t, max_z);
+            rt.sim.uniforms.slice_z = rt.sim.slice.z;
+            fire_nudge(
+                rt,
+                NudgeKind::SliceZ,
+                "SLICE Z".into(),
+                start.to_string(),
+                fmt_slice_z(rt.sim.slice.z),
+            );
+        }
+        HudSlider::Thick => {
+            rt.sim.slice.set_thickness_normalized(t, max_z);
+            fire_nudge(
+                rt,
+                NudgeKind::Thick,
+                "THICK".into(),
+                start.to_string(),
+                fmt_thick(rt.sim.slice.thickness),
+            );
+        }
+        HudSlider::Zoom => {
+            rt.sim.slice.set_zoom_normalized(t);
+            fire_nudge(
+                rt,
+                NudgeKind::Zoom,
+                "ZOOM".into(),
+                start.to_string(),
+                fmt_zoom(rt.sim.slice.zoom),
+            );
+        }
+        HudSlider::Param => {
+            rt.sim.set_param_normalized(t);
+            fire_nudge(
+                rt,
+                NudgeKind::Param,
+                param_title(rt.sim.param_slot),
+                start.to_string(),
+                fmt_param(rt.sim.param_slot, rt.sim.uniforms.param_value(rt.sim.param_slot)),
+            );
+        }
+    }
 }
 
 fn click_dir(

--- a/pycelium-win/src/shaders/present.wgsl
+++ b/pycelium-win/src/shaders/present.wgsl
@@ -47,6 +47,7 @@ struct PresentUniforms {
     help_rect: vec4<f32>,
     tip_rect: vec4<f32>,
     callout: vec4<f32>,
+    nudge_rect: vec4<f32>,
 }
 
 @group(0) @binding(0) var<uniform> u: PresentUniforms;
@@ -66,6 +67,9 @@ const HELP_ROWS: i32 = 22;
 const TIP_COLS: i32 = 36;
 const TIP_ROWS: i32 = 8;
 const TIP_BASE: i32 = 572;
+const NUDGE_COLS: i32 = 28;
+const NUDGE_ROWS: i32 = 3;
+const NUDGE_BASE: i32 = 860;
 
 struct VsOut {
     @builtin(position) clip: vec4<f32>,
@@ -171,6 +175,51 @@ fn bar(uv: vec2<f32>, origin: vec2<f32>, fill: f32, rgb: vec3<f32>) -> vec3<f32>
     let edge = step(0.0, local.x) * step(local.x, 1.0) * step(0.0, local.y) * step(local.y, 1.0);
     let body = select(vec3<f32>(0.08, 0.09, 0.10), rgb, local.x < clamp(fill, 0.0, 1.0));
     return body * edge;
+}
+
+// House chrome slider: thin white frame, 1–2 px shadow, filled track + handle.
+fn knob(uv: vec2<f32>, origin: vec2<f32>, fill: f32, tint: vec3<f32>) -> vec3<f32> {
+    let size = vec2<f32>(0.118, 0.014);
+    let r0 = origin;
+    let r1 = origin + size;
+    if uv.x < r0.x || uv.x > r1.x || uv.y < r0.y || uv.y > r1.y {
+        return vec3<f32>(0.0);
+    }
+    let t = clamp((uv.x - r0.x) / size.x, 0.0, 1.0);
+    let f = clamp(fill, 0.0, 1.0);
+    var rgb = vec3<f32>(0.07, 0.075, 0.08);
+    if t <= f {
+        rgb = mix(tint * 0.22, tint, 0.72);
+    }
+    let p = px();
+    let handle = abs(t - f) < max(p.x / size.x * 2.0, 0.018);
+    if handle {
+        rgb = vec3<f32>(0.94, 0.95, 0.92);
+    }
+    rgb = mix(rgb, vec3<f32>(0.0, 0.0, 0.0), thin_frame(uv, r0 + p * 1.5, r1 + p * 1.5) * 0.40);
+    rgb = mix(rgb, vec3<f32>(0.92, 0.93, 0.90), thin_frame(uv, r0, r1));
+    return rgb;
+}
+
+// Must stay in lockstep with `SimUniforms::param_range`.
+fn param_fill(slot: f32, value: f32) -> f32 {
+    let s = i32(slot + 0.5);
+    if s == 0 || s == 1 || s == 2 {
+        return clamp(value / 3.0, 0.0, 1.0);
+    }
+    if s == 3 {
+        return clamp((value - 0.2) / 2.8, 0.0, 1.0);
+    }
+    if s == 4 {
+        return clamp(value / 0.02, 0.0, 1.0);
+    }
+    if s == 5 {
+        return clamp(value / 0.12, 0.0, 1.0);
+    }
+    if s == 6 {
+        return clamp((value - 0.1) / 1.9, 0.0, 1.0);
+    }
+    return clamp((value - 0.2) / 2.0, 0.0, 1.0);
 }
 
 fn px() -> vec2<f32> {
@@ -285,6 +334,9 @@ fn label_char(id: i32, slot: i32) -> i32 {
         }
         case 30: { // SVG
             switch slot { case 0: { return 19; } case 1: { return 22; } case 2: { return 7; } default: { return -1; } }
+        }
+        case 31: { // HEIGHT
+            switch slot { case 0: { return 8; } case 1: { return 5; } case 2: { return 9; } case 3: { return 7; } case 4: { return 8; } case 5: { return 20; } default: { return -1; } }
         }
         default: { return -1; }
     }
@@ -582,8 +634,8 @@ fn fs_main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
         let ex0 = 0.735;
         let ex1 = 0.985;
         let ey0 = 0.368;
-        let chip1 = 0.418;
-        let ey1 = select(chip1, 0.882, u.export_ui.x >= 0.5);
+        let chip1 = 0.412;
+        let ey1 = select(chip1, 0.848, u.export_ui.x >= 0.5);
         if uv.x >= ex0 && uv.x <= ex1 && uv.y >= ey0 && uv.y <= ey1 {
             let cursor = u.hud_ui.xy;
             let hover = cursor.x >= ex0 && cursor.x <= ex1 && cursor.y >= ey0 && cursor.y <= ey1;
@@ -594,57 +646,83 @@ fn fs_main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
             rgb = mix(rgb, card, 0.88);
             let frame = thin_frame(uv, vec2<f32>(ex0, ey0), vec2<f32>(ex1, ey1));
             rgb = mix(rgb, vec3<f32>(0.80, 0.78, 0.70), frame);
-            rgb = paint_label(uv, vec2<f32>(0.742, 0.378), 19, 1.0, rgb);
+            rgb = paint_label(uv, vec2<f32>(0.742, 0.376), 19, 1.0, rgb);
             let sizes = array<f32, 11>(8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0, 1024.0, 2048.0, 4096.0, 8192.0);
             let preset = i32(u.export_ui.y + 0.5);
             let pidx = clamp(preset, 0, 10);
-            var size_ink = draw_number_trim(uv, vec2<f32>(0.868, 0.382), sizes[pidx], 4);
+            var size_ink = draw_number_trim(uv, vec2<f32>(0.868, 0.380), sizes[pidx], 4);
             rgb = rgb + vec3<f32>(0.95, 0.72, 0.28) * size_ink;
             if u.export_ui.x >= 0.5 {
-                rgb = paint_label(uv, vec2<f32>(0.742, 0.424), 20, 0.85, rgb);
-                let row_h = 0.028;
-                let row0 = 0.448;
+                let flags = i32(u.export_ui.z + 0.5);
+                let native = (flags & 1) != 0;
+                let fit_crop = (flags & 2) != 0;
+                let png_on = (flags & 4) != 0;
+                let mask_on = (flags & 8) != 0;
+                let json_on = (flags & 16) != 0;
+                let svg_on = (flags & 32) != 0;
+                let ht_on = (flags & 64) != 0;
+                rgb = paint_label(uv, vec2<f32>(0.742, 0.416), 20, 0.85, rgb);
+                let row_h = 0.032;
+                let row0 = 0.440;
+                let mid = 0.5 * (ex0 + ex1);
                 for (var i = 0; i < 11; i++) {
-                    let y0 = row0 + f32(i) * row_h;
+                    let row = i / 2;
+                    let col = i % 2;
+                    let x0 = select(ex0, mid, col == 1);
+                    let x1 = select(mid, ex1, col == 1);
+                    let y0 = row0 + f32(row) * row_h;
                     let y1 = y0 + row_h;
                     let sel = i == pidx;
-                    if uv.y >= y0 && uv.y < y1 {
+                    if uv.x >= x0 && uv.x < x1 && uv.y >= y0 && uv.y < y1 {
                         var rowc = select(vec3<f32>(0.06, 0.06, 0.07), vec3<f32>(0.42, 0.20, 0.05), sel);
-                        if cursor.y >= y0 && cursor.y < y1 && cursor.x >= ex0 && cursor.x <= ex1 && !sel {
+                        if cursor.x >= x0 && cursor.x < x1 && cursor.y >= y0 && cursor.y < y1 && !sel {
                             rowc = vec3<f32>(0.10, 0.10, 0.11);
                         }
                         rgb = mix(rgb, rowc, 0.75);
                     }
-                    var ink = draw_number_trim(uv, vec2<f32>(0.802, y0 + 0.005), sizes[i], 4);
+                    var ink = draw_number_trim(uv, vec2<f32>(x0 + 0.018, y0 + 0.008), sizes[i], 4);
                     let tint = select(vec3<f32>(0.78, 0.80, 0.76), vec3<f32>(1.0, 0.72, 0.28), sel);
                     rgb = rgb + tint * ink;
                 }
-                rgb = paint_label(uv, vec2<f32>(0.742, 0.748), 21, 0.8, rgb);
-                let mid = 0.5 * (ex0 + ex1);
-                let fit_crop = u.export_ui.w >= 0.5;
-                let native = u.export_ui.z >= 0.5;
-                if uv.y >= 0.768 && uv.y <= 0.808 {
+                if uv.y >= 0.644 && uv.y <= 0.684 {
                     if uv.x < mid {
                         rgb = mix(rgb, select(vec3<f32>(0.07, 0.07, 0.08), vec3<f32>(0.42, 0.20, 0.05), !fit_crop), 0.7);
                     } else {
                         rgb = mix(rgb, select(vec3<f32>(0.07, 0.07, 0.08), vec3<f32>(0.42, 0.20, 0.05), fit_crop), 0.7);
                     }
                 }
-                rgb = paint_label(uv, vec2<f32>(0.742, 0.776), 22, select(0.55, 1.0, !fit_crop), rgb);
-                rgb = paint_label(uv, vec2<f32>(0.862, 0.776), 23, select(0.55, 1.0, fit_crop), rgb);
-                if uv.y >= 0.816 && uv.y <= 0.856 {
+                rgb = paint_label(uv, vec2<f32>(0.742, 0.652), 22, select(0.55, 1.0, !fit_crop), rgb);
+                rgb = paint_label(uv, vec2<f32>(0.868, 0.652), 23, select(0.55, 1.0, fit_crop), rgb);
+                if uv.y >= 0.692 && uv.y <= 0.732 {
                     if uv.x < mid {
                         rgb = mix(rgb, select(vec3<f32>(0.07, 0.07, 0.08), vec3<f32>(0.42, 0.20, 0.05), !native), 0.7);
                     } else {
                         rgb = mix(rgb, select(vec3<f32>(0.07, 0.07, 0.08), vec3<f32>(0.42, 0.20, 0.05), native), 0.7);
                     }
                 }
-                rgb = paint_label(uv, vec2<f32>(0.742, 0.824), 25, select(0.55, 1.0, !native), rgb);
-                rgb = paint_label(uv, vec2<f32>(0.862, 0.824), 26, select(0.55, 1.0, native), rgb);
-                rgb = paint_label(uv, vec2<f32>(0.742, 0.860), 27, 0.55, rgb);
-                rgb = paint_label(uv, vec2<f32>(0.802, 0.860), 28, 0.55, rgb);
-                rgb = paint_label(uv, vec2<f32>(0.862, 0.860), 29, 0.45, rgb);
-                rgb = paint_label(uv, vec2<f32>(0.922, 0.860), 30, 0.45, rgb);
+                rgb = paint_label(uv, vec2<f32>(0.742, 0.700), 25, select(0.55, 1.0, !native), rgb);
+                rgb = paint_label(uv, vec2<f32>(0.868, 0.700), 26, select(0.55, 1.0, native), rgb);
+                let fw = (ex1 - ex0) * 0.25;
+                let fmt_on = array<i32, 4>(
+                    select(0, 1, png_on),
+                    select(0, 1, mask_on),
+                    select(0, 1, json_on),
+                    select(0, 1, svg_on),
+                );
+                let fmt_id = array<i32, 4>(27, 28, 29, 30);
+                for (var f = 0; f < 4; f++) {
+                    let fx0 = ex0 + fw * f32(f);
+                    let fx1 = fx0 + fw;
+                    let on = fmt_on[f] != 0;
+                    if uv.x >= fx0 && uv.x < fx1 && uv.y >= 0.748 && uv.y <= 0.788 {
+                        rgb = mix(rgb, select(vec3<f32>(0.07, 0.07, 0.08), vec3<f32>(0.42, 0.20, 0.05), on), 0.7);
+                    }
+                    rgb = paint_label(uv, vec2<f32>(fx0 + 0.004, 0.756), fmt_id[f], select(0.45, 1.0, on), rgb);
+                }
+                if uv.y >= 0.796 && uv.y <= 0.836 {
+                    rgb = mix(rgb, select(vec3<f32>(0.07, 0.07, 0.08), vec3<f32>(0.42, 0.20, 0.05), ht_on), 0.7);
+                }
+                rgb = paint_label(uv, vec2<f32>(0.742, 0.804), 31, select(0.45, 1.0, ht_on), rgb);
             }
         }
     }
@@ -698,7 +776,7 @@ fn fs_main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
         ink = ink + draw_number(uv, vec2<f32>(0.168, 0.742), lineage, 3);
         ink = ink + draw_number(uv, vec2<f32>(0.168, 0.784), age, 5);
         ink = ink + draw_number(uv, vec2<f32>(0.168, 0.826), reserve * 100.0, 4);
-        ink = ink + draw_number(uv, vec2<f32>(0.168, 0.896), u.param_slot, 1);
+        ink = ink + draw_number(uv, vec2<f32>(0.168, 0.896), u.param_slot + 1.0, 1);
         ink = ink + draw_number(uv, vec2<f32>(0.188, 0.896), u.param_value * 100.0, 4);
         rgb = rgb + vec3<f32>(0.70, 0.76, 0.72) * ink * 0.85;
         rgb = rgb + bar(uv, vec2<f32>(0.128, 0.312), hypha_f, teal);
@@ -707,6 +785,18 @@ fn fs_main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
         rgb = rgb + bar(uv, vec2<f32>(0.128, 0.438), soln_f, violet);
         rgb = rgb + bar(uv, vec2<f32>(0.128, 0.480), enz_f, green);
         rgb = rgb + bar(uv, vec2<f32>(0.128, 0.522), org_f, brown);
+        let zfill = clamp((u.slice_z - 1.0) / max(f32(u.depth) - 3.0, 1.0), 0.0, 1.0);
+        let tfill = clamp((u.slice_thickness - 1.0) / max(f32(u.depth) - 1.0, 1.0), 0.0, 1.0);
+        let zof = clamp((u.slice_zoom - 0.12) / 0.88, 0.0, 1.0);
+        let pfill = param_fill(u.param_slot, u.param_value);
+        let k0 = knob(uv, vec2<f32>(0.128, 0.576), zfill, warm);
+        let k1 = knob(uv, vec2<f32>(0.128, 0.618), tfill, warm);
+        let k2 = knob(uv, vec2<f32>(0.128, 0.662), zof, warm);
+        let k3 = knob(uv, vec2<f32>(0.128, 0.918), pfill, ice);
+        if k0.x + k0.y + k0.z > 0.0 { rgb = k0; }
+        if k1.x + k1.y + k1.z > 0.0 { rgb = k1; }
+        if k2.x + k2.y + k2.z > 0.0 { rgb = k2; }
+        if k3.x + k3.y + k3.z > 0.0 { rgb = k3; }
 
         rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.058), 0.85, ice);
         rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.100), clamp(live / 400000.0, 0.2, 1.0), teal);
@@ -782,6 +872,7 @@ fn fs_main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
 
     let help_fade = clamp(u.overlay_ui.x, 0.0, 1.0);
     let tip_fade = clamp(u.overlay_ui.y, 0.0, 1.0);
+    let nudge_fade = clamp(u.overlay_ui.z, 0.0, 1.0);
     if help_fade > 0.004 {
         let h0 = u.help_rect.xy;
         let h1 = u.help_rect.zw;
@@ -794,6 +885,12 @@ fn fs_main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
         let t1 = u.tip_rect.zw;
         rgb = paint_card(uv, t0, t1, tip_fade, rgb);
         rgb = paint_grid(uv, t0, t1, TIP_COLS, TIP_ROWS, TIP_BASE, tip_fade, rgb);
+    }
+    if nudge_fade > 0.004 {
+        let n0 = u.nudge_rect.xy;
+        let n1 = u.nudge_rect.zw;
+        rgb = paint_card(uv, n0, n1, nudge_fade, rgb);
+        rgb = paint_grid(uv, n0, n1, NUDGE_COLS, NUDGE_ROWS, NUDGE_BASE, nudge_fade, rgb);
     }
 
     return vec4<f32>(rgb, 1.0);

--- a/pycelium-win/src/teach.rs
+++ b/pycelium-win/src/teach.rs
@@ -7,8 +7,8 @@
 
 use crate::cutter::{SLIDER_X0, SLIDER_X1, SLIDER_Y0, SLIDER_Y1};
 use crate::export_settings::{
-    ASPECT_Y0, ASPECT_Y1, CHIP_Y0, CHIP_Y1, FIT_Y0, FIT_Y1, PANEL_X0, PANEL_X1, PANEL_Y1,
-    PRESET_ROW, PRESET_Y0, SQUARE_PRESETS,
+    ASPECT_Y0, ASPECT_Y1, CHIP_Y0, CHIP_Y1, FIT_Y0, FIT_Y1, FORMAT_Y0, FORMAT_Y1, HT_Y0, HT_Y1,
+    PANEL_X0, PANEL_X1, PANEL_Y1, PRESET_ROW, PRESET_ROWS, PRESET_Y0, SQUARE_PRESETS,
 };
 use crate::hud_font;
 
@@ -16,12 +16,18 @@ pub const HELP_COLS: usize = 26;
 pub const HELP_ROWS: usize = 22;
 pub const TIP_COLS: usize = 36;
 pub const TIP_ROWS: usize = 8;
+pub const NUDGE_COLS: usize = 28;
+pub const NUDGE_ROWS: usize = 3;
 pub const HELP_BASE: usize = 0;
 pub const TIP_BASE: usize = HELP_COLS * HELP_ROWS;
+pub const NUDGE_BASE: usize = TIP_BASE + TIP_COLS * TIP_ROWS;
 pub const OVERLAY_WORDS: usize = 1024;
 
-const HUD_X0: f32 = 0.008;
-const HUD_X1: f32 = 0.250;
+pub const HUD_X0: f32 = 0.008;
+pub const HUD_X1: f32 = 0.250;
+/// Thin framed tracks on SLICE Z / THICK / ZOOM / PARAM. Match `present.wgsl`.
+pub const SLIDER_TRACK_X0: f32 = 0.128;
+pub const SLIDER_TRACK_X1: f32 = 0.246;
 const INSET: [f32; 4] = [0.72, 0.06, 0.98, 0.34];
 
 /// Bottom-right, under the slab inset. When the export card is fully open
@@ -84,6 +90,8 @@ pub enum HoverId {
     ExportSize,
     ExportFit,
     ExportAspect,
+    ExportFormat,
+    ExportHeightmap,
 }
 
 #[derive(Clone, Debug)]
@@ -93,6 +101,7 @@ pub struct OverlayGpu {
     pub help_rect: [f32; 4],
     pub tip_rect: [f32; 4],
     pub callout: [f32; 4],
+    pub nudge_rect: [f32; 4],
 }
 
 impl Default for OverlayGpu {
@@ -103,7 +112,87 @@ impl Default for OverlayGpu {
             help_rect: [0.0; 4],
             tip_rect: [0.0; 4],
             callout: [0.0; 4],
+            nudge_rect: [0.0; 4],
         }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HudSlider {
+    SliceZ,
+    Thick,
+    Zoom,
+    Param,
+}
+
+impl HudSlider {
+    pub fn keys(self) -> &'static str {
+        match self {
+            Self::SliceZ => "[ ] DEPTH  SHIFT COARSE",
+            Self::Thick => "; ' THICK  SHIFT COARSE",
+            Self::Zoom => ", . ZOOM  SHIFT COARSE",
+            Self::Param => "1-8 SELECT  -/= NUDGE",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NudgeKind {
+    Param,
+    SliceZ,
+    Thick,
+    Zoom,
+    Pan,
+}
+
+impl NudgeKind {
+    pub fn keys(self) -> &'static str {
+        match self {
+            Self::Param => "1-8 SELECT  -/= NUDGE",
+            Self::SliceZ => "[ ] DEPTH  SHIFT COARSE",
+            Self::Thick => "; ' THICK  SHIFT COARSE",
+            Self::Zoom => ", . ZOOM  SHIFT COARSE",
+            Self::Pan => "ARROWS PAN  SHIFT COARSE",
+        }
+    }
+
+    fn row_y(self) -> f32 {
+        match self {
+            Self::Param => 0.908,
+            Self::SliceZ => 0.570,
+            Self::Thick => 0.612,
+            Self::Zoom | Self::Pan => 0.656,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct NudgeToast {
+    pub kind: NudgeKind,
+    pub title: String,
+    pub value: String,
+    pub keys: String,
+    pub fade: f32,
+}
+
+pub fn slider_t(x: f32) -> f32 {
+    ((x - SLIDER_TRACK_X0) / (SLIDER_TRACK_X1 - SLIDER_TRACK_X0)).clamp(0.0, 1.0)
+}
+
+pub fn hud_slider_at(uv: (f32, f32)) -> Option<HudSlider> {
+    if uv.0 < HUD_X0 || uv.0 > HUD_X1 {
+        return None;
+    }
+    if uv.1 >= 0.548 && uv.1 < 0.592 {
+        Some(HudSlider::SliceZ)
+    } else if uv.1 >= 0.592 && uv.1 < 0.634 {
+        Some(HudSlider::Thick)
+    } else if uv.1 >= 0.634 && uv.1 < 0.682 {
+        Some(HudSlider::Zoom)
+    } else if uv.1 >= 0.878 && uv.1 < 0.940 {
+        Some(HudSlider::Param)
+    } else {
+        None
     }
 }
 
@@ -199,10 +288,21 @@ pub fn hit_test(
         }
         if export_panel_open && cursor.0 >= PANEL_X0 && cursor.0 <= PANEL_X1 {
             if cursor.1 >= PRESET_Y0
-                && cursor.1 < PRESET_Y0 + PRESET_ROW * SQUARE_PRESETS.len() as f32
+                && cursor.1 < PRESET_Y0 + PRESET_ROW * PRESET_ROWS as f32
             {
                 let mid = cursor.1;
-                return (HoverId::ExportSize, [PANEL_X0, mid]);
+                let i = {
+                    let row = ((cursor.1 - PRESET_Y0) / PRESET_ROW).floor() as i32;
+                    let col = if cursor.0 < 0.5 * (PANEL_X0 + PANEL_X1) {
+                        0
+                    } else {
+                        1
+                    };
+                    row * 2 + col
+                };
+                if i >= 0 && (i as usize) < SQUARE_PRESETS.len() {
+                    return (HoverId::ExportSize, [PANEL_X0, mid]);
+                }
             }
             if cursor.1 >= FIT_Y0 && cursor.1 <= FIT_Y1 {
                 return (HoverId::ExportFit, [PANEL_X0, 0.5 * (FIT_Y0 + FIT_Y1)]);
@@ -211,6 +311,18 @@ pub fn hit_test(
                 return (
                     HoverId::ExportAspect,
                     [PANEL_X0, 0.5 * (ASPECT_Y0 + ASPECT_Y1)],
+                );
+            }
+            if cursor.1 >= FORMAT_Y0 && cursor.1 <= FORMAT_Y1 {
+                return (
+                    HoverId::ExportFormat,
+                    [PANEL_X0, 0.5 * (FORMAT_Y0 + FORMAT_Y1)],
+                );
+            }
+            if cursor.1 >= HT_Y0 && cursor.1 <= HT_Y1 {
+                return (
+                    HoverId::ExportHeightmap,
+                    [PANEL_X0, 0.5 * (HT_Y0 + HT_Y1)],
                 );
             }
             if cursor.1 >= CHIP_Y0 && cursor.1 <= PANEL_Y1 {
@@ -253,6 +365,7 @@ pub fn pack_overlay(
     anchor: [f32; 2],
     help_fade: f32,
     tip_fade: f32,
+    nudge: Option<&NudgeToast>,
 ) -> OverlayGpu {
     let mut out = OverlayGpu::default();
     let help = scheme_rect(export_panel_open && capturing);
@@ -269,9 +382,20 @@ pub fn pack_overlay(
         attach = tip_attach(anchor, tip);
     }
 
+    let mut nudge_rect = [0.0; 4];
+    let mut nudge_fade = 0.0;
+    if let Some(toast) = nudge {
+        if toast.fade > 0.004 {
+            pack_nudge(&mut out.chars, toast);
+            nudge_rect = place_nudge(toast.kind, help, scheme_on);
+            nudge_fade = toast.fade;
+        }
+    }
+
     out.tip_rect = tip;
     out.callout = [anchor[0], anchor[1], attach[0], attach[1]];
-    out.overlay_ui = [help_fade, tip_fade, 0.0, 0.0];
+    out.nudge_rect = nudge_rect;
+    out.overlay_ui = [help_fade, tip_fade, nudge_fade, 0.0];
     out
 }
 
@@ -281,6 +405,30 @@ fn pack_scheme(chars: &mut [u32]) {
         line.push_str(spec.action);
         blit_line(chars, HELP_BASE, HELP_COLS, row, &line);
     }
+}
+
+fn pack_nudge(chars: &mut [u32], toast: &NudgeToast) {
+    blit_line(chars, NUDGE_BASE, NUDGE_COLS, 0, &toast.title);
+    blit_line(chars, NUDGE_BASE, NUDGE_COLS, 1, &toast.value);
+    blit_line(chars, NUDGE_BASE, NUDGE_COLS, 2, &toast.keys);
+}
+
+fn place_nudge(kind: NudgeKind, help: [f32; 4], scheme_on: bool) -> [f32; 4] {
+    let w = 0.268;
+    let h = 0.074;
+    let mut x = 0.258;
+    let mut y = (kind.row_y() - 0.012).clamp(0.012, 0.984 - h);
+    let mut rect = [x, y, x + w, y + h];
+    if scheme_on && rects_overlap(rect, help) {
+        x = (help[2] + 0.012).min(0.990 - w);
+        rect = [x, y, x + w, y + h];
+        if rects_overlap(rect, help) {
+            y = (help[1] - h - 0.012).max(0.012);
+            x = 0.258;
+            rect = [x, y, x + w, y + h];
+        }
+    }
+    rect
 }
 
 fn pack_tip(chars: &mut [u32], id: HoverId) -> usize {
@@ -405,13 +553,13 @@ fn tip_text(id: HoverId) -> &'static str {
             "Uncleaved polymer: raw litter. The fungus cannot eat this until exoenzyme works. A brown bar falling while SOL C rises is the digestion story. This is the pantry still wrapped, not the meal."
         }
         HoverId::SliceZ => {
-            "Depth of the orange view slab and the right-hand inset, in voxels. Keys [ ] move it. This is a viewing plane, not a capture export (press E for that). Shift makes the step coarse."
+            "Depth of the orange view slab and the right-hand inset, in voxels. Keys [ ] move it, or drag the framed slider. This is a viewing plane, not a capture export (press E for that). Shift makes the step coarse."
         }
         HoverId::Thick => {
-            "How many voxels the view slab integrates. Semicolon and quote change it. Thicker slabs stack more layers in the inset so faint hyphae show up. This does not drive the capture cutter."
+            "How many voxels the view slab integrates. Semicolon and quote change it, or drag the framed slider. Thicker slabs stack more layers in the inset so faint hyphae show up. This does not drive the capture cutter."
         }
         HoverId::Zoom => {
-            "How much of the XY field the inset shows, as percent. Comma and period zoom; arrows pan. Shift makes these coarse. It is a loupe on the current Z slab, not camera orbit."
+            "How much of the XY field the inset shows, as percent. Comma and period zoom, arrows pan, or drag the framed slider. Shift makes these coarse. It is a loupe on the current Z slab, not camera orbit."
         }
         HoverId::Tip => {
             "Which apical slot you clicked. Click in the volume to pick the nearest live tip. Capture mode disables pick. Sparse Tab mode keeps this block readable after a pick."
@@ -426,7 +574,7 @@ fn tip_text(id: HoverId) -> &'static str {
             "Internal carbon the picked tip is carrying (shown times 100). Extension and branching spend this. A starved tip stops growing even if soil food is nearby, until uptake refills it."
         }
         HoverId::Param | HoverId::ParamKeys => {
-            "Live knob 1-8: chemotropism, nitrotropism, autotropism, persistence, maintenance, enzyme_k, branch cost, extension. Keys 1-8 select the slot. Minus and equals nudge the value. These do not change RAM presets."
+            "Live knob 1-8: chemotropism, nitrotropism, autotropism, persistence, maintenance, enzyme_k, branch cost, extension. Keys 1-8 select the slot. Minus and equals nudge, or drag the framed slider. A toast shows the name, value, and keys while you tweak."
         }
         HoverId::Help => {
             "H toggles this corner control-scheme panel, always, including in capture. It never writes a heightmap. Hover a row here, or a left HUD meter, for a teach callout on a white string."
@@ -498,7 +646,13 @@ fn tip_text(id: HoverId) -> &'static str {
             "Orthogonal squash of hypha (teal) plus soluble C (rust) in the current Z slab. Same depth, thickness, and zoom as the SLICE Z / THICK / ZOOM meters. Not the capture bake."
         }
         HoverId::ExportSize => {
-            "Square power-of-two export size, 8 through 8192 (8K). Click a row or wheel over the card. Applies when aspect is square. PNG, mask, SVG, and density_u8 use this canvas."
+            "Square power-of-two export size, 8 through 8192 (8K). Click a cell or wheel over the card. Applies when aspect is square. PNG, mask, SVG, and density_u8 use this canvas."
+        }
+        HoverId::ExportFormat => {
+            "Click PNG, MASK, JSON, or SVG to include or skip that file on the next Enter write. At least one file stays armed. These used to be labels only."
+        }
+        HoverId::ExportHeightmap => {
+            "Click to arm the optional heightmap PNG (same as M). Y still picks the height axis. H never writes a heightmap."
         }
     }
 }
@@ -518,6 +672,7 @@ mod tests {
         assert_eq!(m.keys, "M");
         assert_eq!(SCHEME_ROWS.len(), HELP_ROWS);
         assert!(TIP_BASE + TIP_COLS * TIP_ROWS <= OVERLAY_WORDS);
+        assert!(NUDGE_BASE + NUDGE_COLS * NUDGE_ROWS <= OVERLAY_WORDS);
     }
 
     #[test]
@@ -543,6 +698,10 @@ mod tests {
         assert_eq!(id, HoverId::Slider);
         let (id, _) = hit_test((0.80, 0.18), false, false, false);
         assert_eq!(id, HoverId::Inset);
+        let (id, _) = hit_test((0.76, 0.768), false, true, true);
+        assert_eq!(id, HoverId::ExportFormat);
+        let (id, _) = hit_test((0.86, 0.816), false, true, true);
+        assert_eq!(id, HoverId::ExportHeightmap);
     }
 
     #[test]
@@ -554,6 +713,9 @@ mod tests {
         assert!(wrap_text(tip_text(HoverId::Hypha), TIP_COLS).len() <= TIP_ROWS);
         assert!(wrap_text(tip_text(HoverId::Fusions), TIP_COLS).len() <= TIP_ROWS);
         assert!(wrap_text(tip_text(HoverId::Tab), TIP_COLS).len() <= TIP_ROWS);
+        assert!(wrap_text(tip_text(HoverId::Param), TIP_COLS).len() <= TIP_ROWS);
+        assert!(wrap_text(tip_text(HoverId::ExportFormat), TIP_COLS).len() <= TIP_ROWS);
+        assert!(wrap_text(tip_text(HoverId::ExportHeightmap), TIP_COLS).len() <= TIP_ROWS);
     }
 
     #[test]
@@ -567,11 +729,50 @@ mod tests {
             [0.25, 0.11],
             1.0,
             1.0,
+            None,
         );
         assert_eq!(gpu.chars[0], hud_font::encode_char('H'));
         assert!(gpu.chars[TIP_BASE] > 0);
         assert!(gpu.overlay_ui[0] > 0.5);
         assert!(gpu.tip_rect[2] > gpu.tip_rect[0]);
+    }
+
+    #[test]
+    fn pack_writes_nudge_toast() {
+        let toast = NudgeToast {
+            kind: NudgeKind::Param,
+            title: "1 CHEMOTROPISM".into(),
+            value: "1.06 TO 1.10".into(),
+            keys: NudgeKind::Param.keys().into(),
+            fade: 1.0,
+        };
+        let gpu = pack_overlay(
+            false,
+            false,
+            false,
+            HoverId::None,
+            (0.20, 0.90),
+            [0.25, 0.90],
+            0.0,
+            0.0,
+            Some(&toast),
+        );
+        assert_eq!(gpu.chars[NUDGE_BASE], hud_font::encode_char('1'));
+        assert!(gpu.overlay_ui[2] > 0.5);
+        assert!(gpu.nudge_rect[2] > gpu.nudge_rect[0]);
+        assert!(gpu.nudge_rect[0] >= HUD_X1);
+    }
+
+    #[test]
+    fn hud_slider_rows_match_left_panel() {
+        assert_eq!(hud_slider_at((0.16, 0.570)), Some(HudSlider::SliceZ));
+        assert_eq!(hud_slider_at((0.16, 0.610)), Some(HudSlider::Thick));
+        assert_eq!(hud_slider_at((0.16, 0.650)), Some(HudSlider::Zoom));
+        assert_eq!(hud_slider_at((0.16, 0.910)), Some(HudSlider::Param));
+        assert!(hud_slider_at((0.16, 0.110)).is_none());
+        assert!(hud_slider_at((0.40, 0.910)).is_none());
+        assert!((slider_t(SLIDER_TRACK_X0) - 0.0).abs() < 1e-5);
+        assert!((slider_t(SLIDER_TRACK_X1) - 1.0).abs() < 1e-5);
     }
 
     #[test]

--- a/pycelium-win/src/teach.rs
+++ b/pycelium-win/src/teach.rs
@@ -125,17 +125,6 @@ pub enum HudSlider {
     Param,
 }
 
-impl HudSlider {
-    pub fn keys(self) -> &'static str {
-        match self {
-            Self::SliceZ => "[ ] DEPTH  SHIFT COARSE",
-            Self::Thick => "; ' THICK  SHIFT COARSE",
-            Self::Zoom => ", . ZOOM  SHIFT COARSE",
-            Self::Param => "1-8 SELECT  -/= NUDGE",
-        }
-    }
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum NudgeKind {
     Param,

--- a/pycelium-win/src/types.rs
+++ b/pycelium-win/src/types.rs
@@ -125,6 +125,18 @@ impl SimUniforms {
         }
     }
 
+    /// Inclusive knob range. Must stay in lockstep with `present.wgsl` `param_fill`.
+    pub fn param_range(slot: u32) -> (f32, f32) {
+        match slot % 8 {
+            0 | 1 | 2 => (0.0, 3.0),
+            3 => (0.2, 3.0),
+            4 => (0.0, 0.02),
+            5 => (0.0, 0.12),
+            6 => (0.1, 2.0),
+            _ => (0.2, 2.2),
+        }
+    }
+
     pub fn param_value(&self, slot: u32) -> f32 {
         match slot % 8 {
             0 => self.chemo_weight,
@@ -138,18 +150,33 @@ impl SimUniforms {
         }
     }
 
-    pub fn adjust(&mut self, slot: u32, delta: f32) {
-        let scale = |v: &mut f32, lo, hi| *v = (*v + delta).clamp(lo, hi);
+    pub fn param_normalized(&self, slot: u32) -> f32 {
+        let (lo, hi) = Self::param_range(slot);
+        ((self.param_value(slot) - lo) / (hi - lo).max(1.0e-8)).clamp(0.0, 1.0)
+    }
+
+    pub fn set_param(&mut self, slot: u32, value: f32) {
+        let (lo, hi) = Self::param_range(slot);
+        let v = value.clamp(lo, hi);
         match slot % 8 {
-            0 => scale(&mut self.chemo_weight, 0.0, 3.0),
-            1 => scale(&mut self.nitro_weight, 0.0, 3.0),
-            2 => scale(&mut self.auto_weight, 0.0, 3.0),
-            3 => scale(&mut self.persist, 0.2, 3.0),
-            4 => scale(&mut self.maintenance, 0.0, 0.02),
-            5 => scale(&mut self.enzyme_k, 0.0, 0.12),
-            6 => scale(&mut self.branch_cost, 0.1, 2.0),
-            _ => scale(&mut self.max_extension, 0.2, 2.2),
+            0 => self.chemo_weight = v,
+            1 => self.nitro_weight = v,
+            2 => self.auto_weight = v,
+            3 => self.persist = v,
+            4 => self.maintenance = v,
+            5 => self.enzyme_k = v,
+            6 => self.branch_cost = v,
+            _ => self.max_extension = v,
         }
+    }
+
+    pub fn set_normalized(&mut self, slot: u32, t: f32) {
+        let (lo, hi) = Self::param_range(slot);
+        self.set_param(slot, lo + t.clamp(0.0, 1.0) * (hi - lo));
+    }
+
+    pub fn adjust(&mut self, slot: u32, delta: f32) {
+        self.set_param(slot, self.param_value(slot) + delta);
     }
 }
 
@@ -193,7 +220,7 @@ pub struct PresentUniforms {
     pub cutter: [f32; 4],
     /// Export settings card: x = panel open, y = preset index, z = native aspect, w = crop.
     pub export_ui: [f32; 4],
-    /// Overlay fades: x = scheme panel, y = teach tip.
+    /// Overlay fades: x = scheme panel, y = teach tip, z = nudge toast.
     pub overlay_ui: [f32; 4],
     /// Control-scheme panel UV rect (x0,y0,x1,y1).
     pub help_rect: [f32; 4],
@@ -201,6 +228,8 @@ pub struct PresentUniforms {
     pub tip_rect: [f32; 4],
     /// Elbow: xy = hovered control, zw = popup attach.
     pub callout: [f32; 4],
+    /// Live nudge toast UV rect (x0,y0,x1,y1).
+    pub nudge_rect: [f32; 4],
 }
 
 /// Orthogonal section through the pedon. Depth is the plane; thickness is
@@ -225,8 +254,41 @@ impl SliceView {
         }
     }
 
+    pub fn depth_lo_hi(max_z: f32) -> (f32, f32) {
+        (1.0, (max_z - 2.0).max(1.0))
+    }
+
+    pub fn depth_normalized(&self, max_z: f32) -> f32 {
+        let (lo, hi) = Self::depth_lo_hi(max_z);
+        ((self.z - lo) / (hi - lo).max(1.0e-8)).clamp(0.0, 1.0)
+    }
+
+    pub fn set_depth_normalized(&mut self, t: f32, max_z: f32) {
+        let (lo, hi) = Self::depth_lo_hi(max_z);
+        self.z = lo + t.clamp(0.0, 1.0) * (hi - lo);
+    }
+
+    pub fn thickness_normalized(&self, max_z: f32) -> f32 {
+        ((self.thickness - 1.0) / max_z.max(1.0).max(1.0e-8)).clamp(0.0, 1.0)
+    }
+
+    pub fn set_thickness_normalized(&mut self, t: f32, max_z: f32) {
+        self.thickness = 1.0 + t.clamp(0.0, 1.0) * max_z.max(1.0);
+        self.thickness = self.thickness.clamp(1.0, max_z.max(1.0));
+    }
+
+    pub fn zoom_normalized(&self) -> f32 {
+        ((self.zoom - 0.12) / 0.88).clamp(0.0, 1.0)
+    }
+
+    pub fn set_zoom_normalized(&mut self, t: f32) {
+        self.zoom = 0.12 + t.clamp(0.0, 1.0) * 0.88;
+        self.clamp_pan();
+    }
+
     pub fn nudge_depth(&mut self, delta: f32, max_z: f32) {
-        self.z = (self.z + delta).clamp(1.0, (max_z - 2.0).max(1.0));
+        let (lo, hi) = Self::depth_lo_hi(max_z);
+        self.z = (self.z + delta).clamp(lo, hi);
     }
 
     pub fn nudge_thickness(&mut self, delta: f32, max_z: f32) {
@@ -261,6 +323,36 @@ mod tests {
     fn present_uniforms_stay_16_byte_aligned() {
         assert_eq!(std::mem::size_of::<PresentUniforms>() % 16, 0);
         assert!(std::mem::size_of::<PresentUniforms>() >= 176);
-        assert_eq!(std::mem::size_of::<PresentUniforms>(), 16 * 16);
+        assert_eq!(std::mem::size_of::<PresentUniforms>(), 16 * 17);
+    }
+
+    #[test]
+    fn param_normalized_roundtrips_each_slot() {
+        let mut u = SimUniforms::new(32, 32, 16, 64);
+        for slot in 0..8 {
+            u.set_normalized(slot, 0.0);
+            assert!((u.param_normalized(slot) - 0.0).abs() < 1e-5);
+            u.set_normalized(slot, 1.0);
+            assert!((u.param_normalized(slot) - 1.0).abs() < 1e-5);
+            u.set_normalized(slot, 0.5);
+            assert!((u.param_normalized(slot) - 0.5).abs() < 1e-5);
+            let (lo, hi) = SimUniforms::param_range(slot);
+            assert!(u.param_value(slot) > lo - 1e-5 && u.param_value(slot) < hi + 1e-5);
+        }
+    }
+
+    #[test]
+    fn slice_normalized_roundtrips() {
+        let mut s = SliceView::new(40);
+        s.set_depth_normalized(0.0, 40.0);
+        assert!((s.z - 1.0).abs() < 1e-5);
+        s.set_depth_normalized(1.0, 40.0);
+        assert!((s.z - 38.0).abs() < 1e-5);
+        s.set_thickness_normalized(0.0, 40.0);
+        assert!((s.thickness - 1.0).abs() < 1e-5);
+        s.set_zoom_normalized(0.0);
+        assert!((s.zoom - 0.12).abs() < 1e-5);
+        s.set_zoom_normalized(1.0);
+        assert!((s.zoom - 1.0).abs() < 1e-5);
     }
 }

--- a/pycelium-win/src/types.rs
+++ b/pycelium-win/src/types.rs
@@ -346,13 +346,18 @@ mod tests {
         let mut s = SliceView::new(40);
         s.set_depth_normalized(0.0, 40.0);
         assert!((s.z - 1.0).abs() < 1e-5);
+        assert!((s.depth_normalized(40.0) - 0.0).abs() < 1e-5);
         s.set_depth_normalized(1.0, 40.0);
         assert!((s.z - 38.0).abs() < 1e-5);
+        assert!((s.depth_normalized(40.0) - 1.0).abs() < 1e-5);
         s.set_thickness_normalized(0.0, 40.0);
         assert!((s.thickness - 1.0).abs() < 1e-5);
+        assert!((s.thickness_normalized(40.0) - 0.0).abs() < 1e-5);
         s.set_zoom_normalized(0.0);
         assert!((s.zoom - 0.12).abs() < 1e-5);
+        assert!((s.zoom_normalized() - 0.0).abs() < 1e-5);
         s.set_zoom_normalized(1.0);
         assert!((s.zoom - 1.0).abs() < 1e-5);
+        assert!((s.zoom_normalized() - 1.0).abs() < 1e-5);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two related `pycelium-win` HUD/UI fixes.

## A — Left-panel sliders + live tweak feedback

Adjustable left-HUD rows now have house-chrome sliders (thin white frames, 1–2 px pixelated shadows, color fill + handle):

- **SLICE Z**, **THICK**, **ZOOM**
- **PARAM** (slots 1–8: chemotropism, nitrotropism, autotropism, persistence, maintenance, enzyme_k, branch_cost, extension)

Keys stay the same (`1–8` select, `-/=` nudge; `[ ]` `; '` `, .` arrows + Shift). Dragging the track also sets the value. While you nudge or drag, a near-HUD toast shows **slot/name + old → new** and an in-context reminder (`1–8 SELECT  -/= NUDGE`, or the matching slice keys). It fades after a short idle.

Tab rich / sparse / off is unchanged: sliders stay drawn like the field bars, including `off`. **H** control-scheme panel and hover teach from #7 still work; boxes, bars, and sliders stay hit-testable.

## B — Export settings card cut off / unclickable

The open **S** card was too tall for the right column: FIT sat on the 8K row, and **SVG** painted past the card and the window. Format names looked like buttons but had no hit rect.

The card is now a compact two-column size grid that stays under the slab inset and above the thickness slider. **PNG / MASK / JSON / SVG / HEIGHT** are real toggles (click, or **M** / **Y** for heightmap). At least one file stays armed. Hit-tests match the drawn rows.

## Docs / tests

- `docs/HUD_LEGEND.md`, `docs/SLICE_EXPORT.md`, README
- Heightmap write remains **M** (H is the scheme panel)
- `cargo test -p pycelium-win` — GPU window not visually verified in this environment

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-552a10f5-56f8-4142-be57-cb6d78971549?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-552a10f5-56f8-4142-be57-cb6d78971549&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

