### PR TITLE
Eight dedicated left-HUD param sliders with high/low teach copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ python pycelium.py
 
 ### GPU mesocosm (`pycelium-win`)
 
-Windows / wgpu 3D pedon. Left telemetry HUD uses **white sans-serif English** plus a color readout box per row (rich by default; **Tab** cycles rich / sparse / off). Adjustable meters (**SLICE Z**, **THICK**, **ZOOM**, **PARAM**) have framed sliders; tweak keys show a short toast with the name, value, and binds. **H** toggles a corner control-scheme panel; hover a meter for a teach callout. Small 3×5 digits stay on the right. Legend: [docs/HUD_LEGEND.md](docs/HUD_LEGEND.md). Face-aligned **slice export** (`E` capture, `S` settings, `Enter` write PNG/JSON/SVG) defaults to a **512×512** power-of-two square (presets 8…8192): [docs/SLICE_EXPORT.md](docs/SLICE_EXPORT.md). Heightmap write is **M**.
+Windows / wgpu 3D pedon. Left telemetry HUD uses **white sans-serif English** plus a color readout box per row (rich by default; **Tab** cycles rich / sparse / off). Adjustable meters (**SLICE Z**, **THICK**, **ZOOM**, and the eight **PARAM** knobs) have framed sliders; tweak keys show a short toast with the name, value, and binds. **H** toggles a corner control-scheme panel; hover a meter for a teach callout. Small 3×5 digits stay on the right. Legend: [docs/HUD_LEGEND.md](docs/HUD_LEGEND.md). Face-aligned **slice export** (`E` capture, `S` settings, `Enter` write PNG/JSON/SVG) defaults to a **512×512** power-of-two square (presets 8…8192): [docs/SLICE_EXPORT.md](docs/SLICE_EXPORT.md). Heightmap write is **M**.
 
 ```bash
 cargo run -p pycelium-win --release -- --preset demo

--- a/docs/HUD_LEGEND.md
+++ b/docs/HUD_LEGEND.md
@@ -10,7 +10,7 @@ The previous 5×5 captions were sampled with a Y flip against top-left bit packi
 
 - White sans-serif captions (system-UI / grotesque style)
 - Color box at the left of every row (always drawn, including `off`)
-- Thin 1-pixel frames around census / fields / slice / tip / param groups
+- Thin 1-pixel frames around census / fields / slice / tip / param groups (the param group is one shared frame around all eight knobs)
 - Tight 1–2 pixel drop shadow on type (no blur)
 - Density dial: rich (default, full opacity), sparse (hover/pick only), off (boxes + bars + small digits)
 - **H** toggles a compact **control-scheme** panel (bottom-right; slides left of the export card when that card is open)
@@ -57,26 +57,35 @@ Click in the volume to pick the nearest live tip. `hud[10]` is the pick distance
 
 | Row | Box | English | Small digits | Meaning |
 |-----|-----|---------|--------------|---------|
-| 0.70 | teal | `TIP` | 6 | selected tip slot |
-| 0.74 | gold | `LINEAGE` | 3 | inoculum / colony id |
-| 0.78 | ice | `AGE` | 5 | tip age |
-| 0.82 | amber | `RESERVE` | 4 | internal reserve × 100 |
+| 0.69 | teal | `TIP` | 6 | selected tip slot |
+| 0.72 | gold | `LINEAGE` | 3 | inoculum / colony id |
+| 0.75 | ice | `AGE` | 5 | tip age |
+| 0.77 | amber | `RESERVE` | 4 | internal reserve × 100 |
 
 After a pick, sparse mode keeps this block readable.
 
-## Param knob
+## Param knobs (compact group, shared frame)
 
-| Row | Box | English | Small digits | Meaning |
-|-----|-----|---------|--------------|---------|
-| 0.90 | ice | `PARAM` | 1 + 4 | slot `1–8` and value × 100 + slider |
+Eight dedicated sliders replace the old single PARAM row. Tracks are shorter than the slice knobs so the group fits under the compressed tip block without a scroll. Census / fields / slice UV rows are unchanged.
 
-Slots: chemotropism, nitrotropism, autotropism, persistence, maintenance, enzyme_k, branch_cost, extension. Keys `1–8` select, `-` / `=` nudge, or drag the framed track. While adjusting, a toast shows **slot / name / old→new** and `1–8 select  -/= nudge`, then fades after a short idle.
+| Row (UV y0) | Box | English | Slot / sim name |
+|-------------|-----|---------|-----------------|
+| 0.800 | rust | `CHEMO` | 1 chemotropism |
+| 0.823 | violet | `NITRO` | 2 nitrotropism |
+| 0.846 | teal | `AUTO` | 3 autotropism |
+| 0.869 | gold | `PERSIST` | 4 persistence |
+| 0.892 | amber | `MAINT` | 5 maintenance |
+| 0.915 | green | `ENZYME_K` | 6 enzyme_k |
+| 0.938 | ice | `BRANCH` | 7 branch_cost |
+| 0.961 | warm | `EXTEND` | 8 extension |
+
+Keys `1–8` select / focus that row (sparse keeps the selected caption lit). `-` / `=` nudge the selected slot. Drag any framed track to set that slot and select it. While adjusting, a toast shows **slot / name / old→new** and `1–8 select  -/= nudge`, then fades after a short idle. Hover a row for high-vs-low teach copy.
 
 Slice **export** (face-aligned 2D squash / rich box) is a separate capture mode (`E`). It does not change these HUD rows. The export settings card (`S`) lives on the **right**, under the slab inset. See [SLICE_EXPORT.md](SLICE_EXPORT.md).
 
 ## Control scheme + hover teach
 
-**H** opens or hides the corner keybind panel (global, including during capture). Hover any left-HUD meter — FPS through PARAM — or a row on that panel for a verbose plain-English callout (sim meaning, plus terms such as anastomosis, chemotropism, soluble C/N, exoenzyme, cord). The popup sits near the mouse and is tied to the control with a thin white elbow / string (1–2 px shadow, no blur).
+**H** opens or hides the corner keybind panel (global, including during capture). Hover any left-HUD meter — FPS through the eight PARAM sliders — or a row on that panel for a verbose plain-English callout (sim meaning, plus terms such as anastomosis, chemotropism, soluble C/N, exoenzyme, cord). Each param popup says what a high value does versus a low one. The popup sits near the mouse and is tied to the control with a thin white elbow / string (1–2 px shadow, no blur).
 
 Tab `off` still teaches if the cursor is on a color box, bar, or slider. Sliders stay drawn in every density mode (same as bars). If a future chrome piece has no hit box, teach cannot fire for it.
 

--- a/pycelium-win/src/gpu.rs
+++ b/pycelium-win/src/gpu.rs
@@ -431,7 +431,8 @@ impl MyceliumGpu {
         self.uniforms.adjust(self.param_slot, delta);
     }
 
-    pub fn set_param_normalized(&mut self, t: f32) {
+    pub fn set_param_normalized(&mut self, slot: u32, t: f32) {
+        self.param_slot = slot % 8;
         self.uniforms.set_normalized(self.param_slot, t);
     }
 
@@ -498,6 +499,16 @@ impl MyceliumGpu {
             selected_reserve: 0.0,
             param_slot: self.param_slot as f32,
             param_value: self.uniforms.param_value(self.param_slot),
+            param_fills: [
+                self.uniforms.param_normalized(0),
+                self.uniforms.param_normalized(1),
+                self.uniforms.param_normalized(2),
+                self.uniforms.param_normalized(3),
+                self.uniforms.param_normalized(4),
+                self.uniforms.param_normalized(5),
+                self.uniforms.param_normalized(6),
+                self.uniforms.param_normalized(7),
+            ],
             soluble_c: 0.0,
             soluble_n: 0.0,
             slice_thickness: self.slice.thickness,

--- a/pycelium-win/src/main.rs
+++ b/pycelium-win/src/main.rs
@@ -358,10 +358,13 @@ impl ApplicationHandler<AppAction> for App {
                                 HudSlider::SliceZ => fmt_slice_z(rt.sim.slice.z),
                                 HudSlider::Thick => fmt_thick(rt.sim.slice.thickness),
                                 HudSlider::Zoom => fmt_zoom(rt.sim.slice.zoom),
-                                HudSlider::Param => fmt_param(
-                                    rt.sim.param_slot,
-                                    rt.sim.uniforms.param_value(rt.sim.param_slot),
-                                ),
+                                HudSlider::Param(slot) => {
+                                    rt.sim.param_slot = slot as u32;
+                                    fmt_param(
+                                        rt.sim.param_slot,
+                                        rt.sim.uniforms.param_value(rt.sim.param_slot),
+                                    )
+                                }
                             };
                             if rt.cursor.0 >= teach::SLIDER_TRACK_X0 {
                                 apply_hud_slider(rt, slider, rt.cursor.0, &start);
@@ -388,7 +391,7 @@ impl ApplicationHandler<AppAction> for App {
                                         start.clone(),
                                         start.clone(),
                                     ),
-                                    HudSlider::Param => fire_nudge(
+                                    HudSlider::Param(_) => fire_nudge(
                                         rt,
                                         NudgeKind::Param,
                                         param_title(rt.sim.param_slot),
@@ -955,12 +958,17 @@ fn current_nudge(rt: &Runtime) -> Option<NudgeToast> {
     } else {
         format!("{} TO {}", n.old, n.new)
     };
+    let row_y = match n.kind {
+        NudgeKind::Param => teach::param_row_mid(rt.sim.param_slot),
+        other => other.row_y(),
+    };
     Some(NudgeToast {
         kind: n.kind,
         title: n.title.to_ascii_uppercase(),
         value,
         keys: n.kind.keys().to_string(),
         fade,
+        row_y,
     })
 }
 
@@ -999,8 +1007,8 @@ fn apply_hud_slider(rt: &mut Runtime, slider: HudSlider, x: f32, start: &str) {
                 fmt_zoom(rt.sim.slice.zoom),
             );
         }
-        HudSlider::Param => {
-            rt.sim.set_param_normalized(t);
+        HudSlider::Param(slot) => {
+            rt.sim.set_param_normalized(slot as u32, t);
             fire_nudge(
                 rt,
                 NudgeKind::Param,

--- a/pycelium-win/src/shaders/present.wgsl
+++ b/pycelium-win/src/shaders/present.wgsl
@@ -48,6 +48,8 @@ struct PresentUniforms {
     tip_rect: vec4<f32>,
     callout: vec4<f32>,
     nudge_rect: vec4<f32>,
+    params_a: vec4<f32>,
+    params_b: vec4<f32>,
 }
 
 @group(0) @binding(0) var<uniform> u: PresentUniforms;
@@ -178,8 +180,7 @@ fn bar(uv: vec2<f32>, origin: vec2<f32>, fill: f32, rgb: vec3<f32>) -> vec3<f32>
 }
 
 // House chrome slider: thin white frame, 1–2 px shadow, filled track + handle.
-fn knob(uv: vec2<f32>, origin: vec2<f32>, fill: f32, tint: vec3<f32>) -> vec3<f32> {
-    let size = vec2<f32>(0.118, 0.014);
+fn knob_at(uv: vec2<f32>, origin: vec2<f32>, fill: f32, tint: vec3<f32>, size: vec2<f32>) -> vec3<f32> {
     let r0 = origin;
     let r1 = origin + size;
     if uv.x < r0.x || uv.x > r1.x || uv.y < r0.y || uv.y > r1.y {
@@ -201,25 +202,12 @@ fn knob(uv: vec2<f32>, origin: vec2<f32>, fill: f32, tint: vec3<f32>) -> vec3<f3
     return rgb;
 }
 
-// Must stay in lockstep with `SimUniforms::param_range`.
-fn param_fill(slot: f32, value: f32) -> f32 {
-    let s = i32(slot + 0.5);
-    if s == 0 || s == 1 || s == 2 {
-        return clamp(value / 3.0, 0.0, 1.0);
-    }
-    if s == 3 {
-        return clamp((value - 0.2) / 2.8, 0.0, 1.0);
-    }
-    if s == 4 {
-        return clamp(value / 0.02, 0.0, 1.0);
-    }
-    if s == 5 {
-        return clamp(value / 0.12, 0.0, 1.0);
-    }
-    if s == 6 {
-        return clamp((value - 0.1) / 1.9, 0.0, 1.0);
-    }
-    return clamp((value - 0.2) / 2.0, 0.0, 1.0);
+fn knob(uv: vec2<f32>, origin: vec2<f32>, fill: f32, tint: vec3<f32>) -> vec3<f32> {
+    return knob_at(uv, origin, fill, tint, vec2<f32>(0.118, 0.014));
+}
+
+fn knob_compact(uv: vec2<f32>, origin: vec2<f32>, fill: f32, tint: vec3<f32>) -> vec3<f32> {
+    return knob_at(uv, origin, fill, tint, vec2<f32>(0.118, 0.010));
 }
 
 fn px() -> vec2<f32> {
@@ -338,13 +326,37 @@ fn label_char(id: i32, slot: i32) -> i32 {
         case 31: { // HEIGHT
             switch slot { case 0: { return 8; } case 1: { return 5; } case 2: { return 9; } case 3: { return 7; } case 4: { return 8; } case 5: { return 20; } default: { return -1; } }
         }
+        case 32: { // CHEMO
+            switch slot { case 0: { return 3; } case 1: { return 8; } case 2: { return 5; } case 3: { return 13; } case 4: { return 15; } default: { return -1; } }
+        }
+        case 33: { // NITRO
+            switch slot { case 0: { return 14; } case 1: { return 9; } case 2: { return 20; } case 3: { return 18; } case 4: { return 15; } default: { return -1; } }
+        }
+        case 34: { // AUTO
+            switch slot { case 0: { return 1; } case 1: { return 21; } case 2: { return 20; } case 3: { return 15; } default: { return -1; } }
+        }
+        case 35: { // PERSIST
+            switch slot { case 0: { return 16; } case 1: { return 5; } case 2: { return 18; } case 3: { return 19; } case 4: { return 9; } case 5: { return 19; } case 6: { return 20; } default: { return -1; } }
+        }
+        case 36: { // MAINT
+            switch slot { case 0: { return 13; } case 1: { return 1; } case 2: { return 9; } case 3: { return 14; } case 4: { return 20; } default: { return -1; } }
+        }
+        case 37: { // ENZYME_K
+            switch slot { case 0: { return 5; } case 1: { return 14; } case 2: { return 26; } case 3: { return 25; } case 4: { return 13; } case 5: { return 5; } case 6: { return 41; } case 7: { return 11; } default: { return -1; } }
+        }
+        case 38: { // BRANCH
+            switch slot { case 0: { return 2; } case 1: { return 18; } case 2: { return 1; } case 3: { return 14; } case 4: { return 3; } case 5: { return 8; } default: { return -1; } }
+        }
+        case 39: { // EXTEND
+            switch slot { case 0: { return 5; } case 1: { return 24; } case 2: { return 20; } case 3: { return 5; } case 4: { return 14; } case 5: { return 4; } default: { return -1; } }
+        }
         default: { return -1; }
     }
 }
 
-fn draw_label(uv: vec2<f32>, origin: vec2<f32>, id: i32) -> f32 {
+fn draw_label_sz(uv: vec2<f32>, origin: vec2<f32>, id: i32, gw: f32, gh: f32) -> f32 {
     let n = 8.0;
-    let local = (uv - origin) / vec2<f32>(0.0112 * n, 0.022);
+    let local = (uv - origin) / vec2<f32>(gw * n, gh);
     if local.x < 0.0 || local.x > 1.0 || local.y < 0.0 || local.y > 1.0 {
         return 0.0;
     }
@@ -353,6 +365,10 @@ fn draw_label(uv: vec2<f32>, origin: vec2<f32>, id: i32) -> f32 {
     let ch = label_char(id, slot);
     if ch < 0 { return 0.0; }
     return letter(cell, ch);
+}
+
+fn draw_label(uv: vec2<f32>, origin: vec2<f32>, id: i32) -> f32 {
+    return draw_label_sz(uv, origin, id, 0.0112, 0.022);
 }
 
 fn sd_seg(p: vec2<f32>, a: vec2<f32>, b: vec2<f32>) -> f32 {
@@ -461,27 +477,48 @@ fn row_alpha(cursor: vec2<f32>, y0: f32, y1: f32, density: f32, fade: f32, picke
     return clamp(max(focus, hover), 0.0, 1.0) * fade;
 }
 
-fn paint_label(uv: vec2<f32>, origin: vec2<f32>, id: i32, alpha: f32, rgb: vec3<f32>) -> vec3<f32> {
+fn paint_label_sz(uv: vec2<f32>, origin: vec2<f32>, id: i32, alpha: f32, gw: f32, gh: f32, rgb: vec3<f32>) -> vec3<f32> {
     if alpha <= 0.004 {
         return rgb;
     }
-    let shadow = draw_label(uv, origin + px() * 1.5, id);
-    let ink = draw_label(uv, origin, id);
+    let shadow = draw_label_sz(uv, origin + px() * 1.5, id, gw, gh);
+    let ink = draw_label_sz(uv, origin, id, gw, gh);
     var out = rgb;
     out = mix(out, vec3<f32>(0.0, 0.0, 0.0), shadow * alpha * 0.45);
     out = mix(out, vec3<f32>(1.0, 1.0, 1.0), ink * alpha);
     return out;
 }
 
-fn swatch(uv: vec2<f32>, origin: vec2<f32>, fill: f32, tint: vec3<f32>) -> vec3<f32> {
-    let local = (uv - origin) / vec2<f32>(0.015, 0.018);
+fn paint_label(uv: vec2<f32>, origin: vec2<f32>, id: i32, alpha: f32, rgb: vec3<f32>) -> vec3<f32> {
+    return paint_label_sz(uv, origin, id, alpha, 0.0112, 0.022, rgb);
+}
+
+fn swatch_sz(uv: vec2<f32>, origin: vec2<f32>, fill: f32, tint: vec3<f32>, size: vec2<f32>) -> vec3<f32> {
+    let local = (uv - origin) / size;
     if local.x < 0.0 || local.x > 1.0 || local.y < 0.0 || local.y > 1.0 {
         return vec3<f32>(0.0);
     }
     let p = px();
-    let edge = local.x < p.x / 0.015 || local.x > 1.0 - p.x / 0.015 || local.y < p.y / 0.018 || local.y > 1.0 - p.y / 0.018;
+    let edge = local.x < p.x / size.x || local.x > 1.0 - p.x / size.x || local.y < p.y / size.y || local.y > 1.0 - p.y / size.y;
     let body = mix(tint * 0.18, tint, clamp(fill, 0.22, 1.0));
     return select(body, vec3<f32>(0.92, 0.93, 0.90), edge);
+}
+
+fn swatch(uv: vec2<f32>, origin: vec2<f32>, fill: f32, tint: vec3<f32>) -> vec3<f32> {
+    return swatch_sz(uv, origin, fill, tint, vec2<f32>(0.015, 0.018));
+}
+
+fn param_fill_at(slot: i32) -> f32 {
+    switch slot {
+        case 0: { return u.params_a.x; }
+        case 1: { return u.params_a.y; }
+        case 2: { return u.params_a.z; }
+        case 3: { return u.params_a.w; }
+        case 4: { return u.params_b.x; }
+        case 5: { return u.params_b.y; }
+        case 6: { return u.params_b.z; }
+        default: { return u.params_b.w; }
+    }
 }
 
 @fragment
@@ -772,12 +809,10 @@ fn fs_main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
         ink = ink + draw_number(uv, vec2<f32>(0.168, 0.558), u.slice_z, 4);
         ink = ink + draw_number(uv, vec2<f32>(0.168, 0.600), u.slice_thickness, 3);
         ink = ink + draw_number(uv, vec2<f32>(0.168, 0.642), u.slice_zoom * 100.0, 3);
-        ink = ink + draw_number(uv, vec2<f32>(0.168, 0.700), f32(sid), 6);
-        ink = ink + draw_number(uv, vec2<f32>(0.168, 0.742), lineage, 3);
-        ink = ink + draw_number(uv, vec2<f32>(0.168, 0.784), age, 5);
-        ink = ink + draw_number(uv, vec2<f32>(0.168, 0.826), reserve * 100.0, 4);
-        ink = ink + draw_number(uv, vec2<f32>(0.168, 0.896), u.param_slot + 1.0, 1);
-        ink = ink + draw_number(uv, vec2<f32>(0.188, 0.896), u.param_value * 100.0, 4);
+        ink = ink + draw_number(uv, vec2<f32>(0.168, 0.694), f32(sid), 6);
+        ink = ink + draw_number(uv, vec2<f32>(0.168, 0.720), lineage, 3);
+        ink = ink + draw_number(uv, vec2<f32>(0.168, 0.746), age, 5);
+        ink = ink + draw_number(uv, vec2<f32>(0.168, 0.772), reserve * 100.0, 4);
         rgb = rgb + vec3<f32>(0.70, 0.76, 0.72) * ink * 0.85;
         rgb = rgb + bar(uv, vec2<f32>(0.128, 0.312), hypha_f, teal);
         rgb = rgb + bar(uv, vec2<f32>(0.128, 0.354), cord_f, amber);
@@ -788,15 +823,34 @@ fn fs_main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
         let zfill = clamp((u.slice_z - 1.0) / max(f32(u.depth) - 3.0, 1.0), 0.0, 1.0);
         let tfill = clamp((u.slice_thickness - 1.0) / max(f32(u.depth) - 1.0, 1.0), 0.0, 1.0);
         let zof = clamp((u.slice_zoom - 0.12) / 0.88, 0.0, 1.0);
-        let pfill = param_fill(u.param_slot, u.param_value);
         let k0 = knob(uv, vec2<f32>(0.128, 0.576), zfill, warm);
         let k1 = knob(uv, vec2<f32>(0.128, 0.618), tfill, warm);
         let k2 = knob(uv, vec2<f32>(0.128, 0.662), zof, warm);
-        let k3 = knob(uv, vec2<f32>(0.128, 0.918), pfill, ice);
         if k0.x + k0.y + k0.z > 0.0 { rgb = k0; }
         if k1.x + k1.y + k1.z > 0.0 { rgb = k1; }
         if k2.x + k2.y + k2.z > 0.0 { rgb = k2; }
-        if k3.x + k3.y + k3.z > 0.0 { rgb = k3; }
+
+        let psel = i32(u.param_slot + 0.5);
+        let ptint = array<vec3<f32>, 8>(
+            rust, violet, teal, gold, amber, green, ice, warm
+        );
+        for (var pi = 0; pi < 8; pi++) {
+            let y0 = 0.800 + f32(pi) * 0.023;
+            let sel = pi == psel;
+            let tint = ptint[pi];
+            let fill = param_fill_at(pi);
+            let kn = knob_compact(uv, vec2<f32>(0.128, y0 + 0.006), fill, tint);
+            if kn.x + kn.y + kn.z > 0.0 {
+                rgb = kn;
+            }
+            rgb = rgb + swatch_sz(
+                uv,
+                vec2<f32>(0.012, y0 + 0.004),
+                select(0.45, 0.95, sel),
+                tint,
+                vec2<f32>(0.015, 0.014)
+            );
+        }
 
         rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.058), 0.85, ice);
         rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.100), clamp(live / 400000.0, 0.2, 1.0), teal);
@@ -812,11 +866,10 @@ fn fs_main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
         rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.558), 0.7, warm);
         rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.600), 0.55, warm);
         rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.642), 0.4, warm);
-        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.700), select(0.25, 0.9, sid < 20000000u), teal);
-        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.742), select(0.25, 0.75, sid < 20000000u), gold);
-        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.784), select(0.25, 0.6, sid < 20000000u), ice);
-        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.826), select(0.25, clamp(reserve, 0.25, 1.0), sid < 20000000u), amber);
-        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.896), 0.7, ice);
+        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.694), select(0.25, 0.9, sid < 20000000u), teal);
+        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.720), select(0.25, 0.75, sid < 20000000u), gold);
+        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.746), select(0.25, 0.6, sid < 20000000u), ice);
+        rgb = rgb + swatch(uv, vec2<f32>(0.012, 0.772), select(0.25, clamp(reserve, 0.25, 1.0), sid < 20000000u), amber);
 
         let cursor = u.hud_ui.xy;
         let density = u.hud_ui.z;
@@ -826,8 +879,8 @@ fn fs_main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
         rgb = mix(rgb, vec3<f32>(0.72, 0.74, 0.70), thin_frame(uv, vec2<f32>(0.008, 0.048), vec2<f32>(0.250, 0.258)) * chrome);
         rgb = mix(rgb, vec3<f32>(0.72, 0.74, 0.70), thin_frame(uv, vec2<f32>(0.008, 0.300), vec2<f32>(0.250, 0.548)) * chrome);
         rgb = mix(rgb, vec3<f32>(0.72, 0.74, 0.70), thin_frame(uv, vec2<f32>(0.008, 0.548), vec2<f32>(0.250, 0.682)) * chrome);
-        rgb = mix(rgb, vec3<f32>(0.72, 0.74, 0.70), thin_frame(uv, vec2<f32>(0.008, 0.688), vec2<f32>(0.250, 0.862)) * chrome);
-        rgb = mix(rgb, vec3<f32>(0.72, 0.74, 0.70), thin_frame(uv, vec2<f32>(0.008, 0.878), vec2<f32>(0.250, 0.938)) * chrome);
+        rgb = mix(rgb, vec3<f32>(0.72, 0.74, 0.70), thin_frame(uv, vec2<f32>(0.008, 0.688), vec2<f32>(0.250, 0.792)) * chrome);
+        rgb = mix(rgb, vec3<f32>(0.72, 0.74, 0.70), thin_frame(uv, vec2<f32>(0.008, 0.800), vec2<f32>(0.250, 0.984)) * chrome);
 
         let a0 = row_alpha(cursor, 0.050, 0.095, density, fade, false);
         let a1 = row_alpha(cursor, 0.095, 0.137, density, fade, false);
@@ -843,11 +896,10 @@ fn fs_main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
         let a11 = row_alpha(cursor, 0.548, 0.592, density, fade, false);
         let a12 = row_alpha(cursor, 0.592, 0.634, density, fade, false);
         let a13 = row_alpha(cursor, 0.634, 0.682, density, fade, false);
-        let a14 = row_alpha(cursor, 0.688, 0.734, density, fade, picked);
-        let a15 = row_alpha(cursor, 0.734, 0.776, density, fade, picked);
-        let a16 = row_alpha(cursor, 0.776, 0.818, density, fade, picked);
-        let a17 = row_alpha(cursor, 0.818, 0.862, density, fade, picked);
-        let a18 = row_alpha(cursor, 0.878, 0.940, density, fade, false);
+        let a14 = row_alpha(cursor, 0.688, 0.714, density, fade, picked);
+        let a15 = row_alpha(cursor, 0.714, 0.740, density, fade, picked);
+        let a16 = row_alpha(cursor, 0.740, 0.766, density, fade, picked);
+        let a17 = row_alpha(cursor, 0.766, 0.792, density, fade, picked);
 
         rgb = paint_label(uv, vec2<f32>(0.032, 0.054), 0, a0, rgb);
         rgb = paint_label(uv, vec2<f32>(0.032, 0.096), 1, a1, rgb);
@@ -863,11 +915,17 @@ fn fs_main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
         rgb = paint_label(uv, vec2<f32>(0.032, 0.554), 11, a11, rgb);
         rgb = paint_label(uv, vec2<f32>(0.032, 0.596), 12, a12, rgb);
         rgb = paint_label(uv, vec2<f32>(0.032, 0.638), 13, a13, rgb);
-        rgb = paint_label(uv, vec2<f32>(0.032, 0.696), 14, a14, rgb);
-        rgb = paint_label(uv, vec2<f32>(0.032, 0.738), 15, a15, rgb);
-        rgb = paint_label(uv, vec2<f32>(0.032, 0.780), 16, a16, rgb);
-        rgb = paint_label(uv, vec2<f32>(0.032, 0.822), 17, a17, rgb);
-        rgb = paint_label(uv, vec2<f32>(0.032, 0.892), 18, a18, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.690), 14, a14, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.716), 15, a15, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.742), 16, a16, rgb);
+        rgb = paint_label(uv, vec2<f32>(0.032, 0.768), 17, a17, rgb);
+        for (var pi = 0; pi < 8; pi++) {
+            let y0 = 0.800 + f32(pi) * 0.023;
+            let y1 = y0 + 0.023;
+            let sel = pi == psel;
+            let pa = row_alpha(cursor, y0, y1, density, fade, sel);
+            rgb = paint_label_sz(uv, vec2<f32>(0.032, y0 + 0.003), 32 + pi, pa, 0.0096, 0.016, rgb);
+        }
     }
 
     let help_fade = clamp(u.overlay_ui.x, 0.0, 1.0);

--- a/pycelium-win/src/teach.rs
+++ b/pycelium-win/src/teach.rs
@@ -196,6 +196,8 @@ impl NudgeKind {
 
 #[derive(Clone, Debug)]
 pub struct NudgeToast {
+    /// Which meter this toast belongs to (also drives `keys` / `row_y` at the call site).
+    #[allow(dead_code)]
     pub kind: NudgeKind,
     pub title: String,
     pub value: String,
@@ -615,7 +617,7 @@ fn tip_text(id: HoverId) -> &'static str {
             "Internal carbon the picked tip is carrying (shown times 100). Extension and branching spend this. A starved tip stops growing even if soil food is nearby, until uptake refills it."
         }
         HoverId::Param | HoverId::ParamKeys => {
-            "Eight live knobs, each with its own left-HUD slider: chemotropism, nitrotropism, autotropism, persistence, maintenance, enzyme_k, branch cost, extension. Keys 1-8 select and focus. Minus and equals nudge the selected slot. Drag any track to set that value and select it."
+            "Eight left-HUD sliders: chemotropism, nitrotropism, autotropism, persistence, maintenance, enzyme_k, branch cost, extension. Keys 1-8 select. Minus and equals nudge the focused slot. Drag any track to set it and select it."
         }
         HoverId::ParamChemo => {
             "Chemotropism steers each tip toward soluble carbon, the rust SOL C field. High: tips hunt food plumes and bend hard toward litter. Low: they ignore C gradients and wander or follow persistence, nitrogen, or autotropism instead. Key 1. Drag the track or use minus and equals."
@@ -630,13 +632,13 @@ fn tip_text(id: HoverId) -> &'static str {
             "Persistence keeps the current heading versus turning to tropisms. High: long straight runs; the tip commits and only slowly bends. Low: twitchy steering, yanked by every nearby C, N, or self gradient. High persist plus high chemo still hunts, but in smoother arcs. Key 4."
         }
         HoverId::ParamMaint => {
-            "Maintenance is the carbon living biomass burns just to stay alive, even when not growing. High: the network is expensive; cords and hyphae drain internal C and can thin if unfed. Low: cheap upkeep, so a colony banks reserve and survives lean soil. A tax on existing walls, not tip steps. Key 5."
+            "Maintenance is the carbon living biomass burns just to stay alive. High: the network is expensive; cords and hyphae drain internal C and can thin if unfed. Low: cheap upkeep, so a colony banks reserve and survives lean soil. A tax on walls, not tip steps. Key 5."
         }
         HoverId::ParamEnzyme => {
-            "Enzyme_k scales how fast leaked exoenzyme cuts ORGANIC polymer into soluble C and N. High: litter unlocks quickly; SOL C and SOL N rise while the brown ORGANIC bar falls. Low: enzyme sits on uncleaved polymer and the meal stays wrapped. Outside digestion, not uptake at the tip. Key 6."
+            "Enzyme_k scales how fast leaked exoenzyme cuts ORGANIC polymer into soluble C and N. High: litter unlocks quickly; SOL C and SOL N rise while the brown ORGANIC bar falls. Low: enzyme sits on uncleaved polymer and the meal stays wrapped. This is outside digestion. Key 6."
         }
         HoverId::ParamBranch => {
-            "Branch cost is how much internal reserve a tip must hold before it can birth a side tip. High: forks are expensive; fewer branches, longer unbranched runs. Low: cheap forks, denser trees, more tips hunting litter, and more carbon spent on new heads. Watch the BRANCHES census. Key 7."
+            "Branch cost is how much reserve a tip must hold before it can birth a side tip. High: forks are expensive; fewer branches, longer unbranched runs. Low: cheap forks, denser trees, more tips hunting litter, and more carbon spent on new heads. Watch the BRANCHES census. Key 7."
         }
         HoverId::ParamExtend => {
             "Extension (max_extension) is how far a tip steps each tick when it has reserve. High: fast explorers that cover voxels quickly, but they can overshoot food and spend reserve faster. Low: short cautious steps; the colony creeps. Starved tips still take shorter steps. Key 8."

--- a/pycelium-win/src/teach.rs
+++ b/pycelium-win/src/teach.rs
@@ -25,9 +25,17 @@ pub const OVERLAY_WORDS: usize = 1024;
 
 pub const HUD_X0: f32 = 0.008;
 pub const HUD_X1: f32 = 0.250;
-/// Thin framed tracks on SLICE Z / THICK / ZOOM / PARAM. Match `present.wgsl`.
+/// Thin framed tracks on SLICE Z / THICK / ZOOM / the eight PARAM rows. Match `present.wgsl`.
 pub const SLIDER_TRACK_X0: f32 = 0.128;
 pub const SLIDER_TRACK_X1: f32 = 0.246;
+/// Compressed tip block so eight compact param sliders fit without a scroll.
+pub const TIP_BLOCK_Y0: f32 = 0.688;
+pub const TIP_BLOCK_Y1: f32 = 0.792;
+pub const TIP_ROW_H: f32 = 0.026;
+/// Shared param group. Eight rows; smaller tracks than the slice knobs.
+pub const PARAM_BLOCK_Y0: f32 = 0.800;
+pub const PARAM_BLOCK_Y1: f32 = 0.984;
+pub const PARAM_ROW_H: f32 = 0.023;
 const INSET: [f32; 4] = [0.72, 0.06, 0.98, 0.34];
 
 /// Bottom-right, under the slab inset. When the export card is fully open
@@ -62,6 +70,14 @@ pub enum HoverId {
     Age,
     Reserve,
     Param,
+    ParamChemo,
+    ParamNitro,
+    ParamAuto,
+    ParamPersist,
+    ParamMaint,
+    ParamEnzyme,
+    ParamBranch,
+    ParamExtend,
     Help,
     Orbit,
     Dolly,
@@ -122,7 +138,30 @@ pub enum HudSlider {
     SliceZ,
     Thick,
     Zoom,
-    Param,
+    Param(u8),
+}
+
+pub fn param_row(slot: u32) -> (f32, f32) {
+    let y0 = PARAM_BLOCK_Y0 + (slot % 8) as f32 * PARAM_ROW_H;
+    (y0, y0 + PARAM_ROW_H)
+}
+
+pub fn param_row_mid(slot: u32) -> f32 {
+    let (y0, y1) = param_row(slot);
+    0.5 * (y0 + y1)
+}
+
+pub fn param_hover(slot: u32) -> HoverId {
+    match slot % 8 {
+        0 => HoverId::ParamChemo,
+        1 => HoverId::ParamNitro,
+        2 => HoverId::ParamAuto,
+        3 => HoverId::ParamPersist,
+        4 => HoverId::ParamMaint,
+        5 => HoverId::ParamEnzyme,
+        6 => HoverId::ParamBranch,
+        _ => HoverId::ParamExtend,
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -145,9 +184,9 @@ impl NudgeKind {
         }
     }
 
-    fn row_y(self) -> f32 {
+    pub fn row_y(self) -> f32 {
         match self {
-            Self::Param => 0.908,
+            Self::Param => param_row_mid(0),
             Self::SliceZ => 0.570,
             Self::Thick => 0.612,
             Self::Zoom | Self::Pan => 0.656,
@@ -162,6 +201,7 @@ pub struct NudgeToast {
     pub value: String,
     pub keys: String,
     pub fade: f32,
+    pub row_y: f32,
 }
 
 pub fn slider_t(x: f32) -> f32 {
@@ -178,8 +218,13 @@ pub fn hud_slider_at(uv: (f32, f32)) -> Option<HudSlider> {
         Some(HudSlider::Thick)
     } else if uv.1 >= 0.634 && uv.1 < 0.682 {
         Some(HudSlider::Zoom)
-    } else if uv.1 >= 0.878 && uv.1 < 0.940 {
-        Some(HudSlider::Param)
+    } else if uv.1 >= PARAM_BLOCK_Y0 && uv.1 < PARAM_BLOCK_Y1 {
+        let i = ((uv.1 - PARAM_BLOCK_Y0) / PARAM_ROW_H).floor() as i32;
+        if (0..8).contains(&i) {
+            Some(HudSlider::Param(i as u8))
+        } else {
+            None
+        }
     } else {
         None
     }
@@ -206,11 +251,18 @@ const HUD_ROWS: &[HudRow] = &[
     HudRow { id: HoverId::SliceZ, y0: 0.548, y1: 0.592 },
     HudRow { id: HoverId::Thick, y0: 0.592, y1: 0.634 },
     HudRow { id: HoverId::Zoom, y0: 0.634, y1: 0.682 },
-    HudRow { id: HoverId::Tip, y0: 0.688, y1: 0.734 },
-    HudRow { id: HoverId::Lineage, y0: 0.734, y1: 0.776 },
-    HudRow { id: HoverId::Age, y0: 0.776, y1: 0.818 },
-    HudRow { id: HoverId::Reserve, y0: 0.818, y1: 0.862 },
-    HudRow { id: HoverId::Param, y0: 0.878, y1: 0.940 },
+    HudRow { id: HoverId::Tip, y0: 0.688, y1: 0.714 },
+    HudRow { id: HoverId::Lineage, y0: 0.714, y1: 0.740 },
+    HudRow { id: HoverId::Age, y0: 0.740, y1: 0.766 },
+    HudRow { id: HoverId::Reserve, y0: 0.766, y1: 0.792 },
+    HudRow { id: HoverId::ParamChemo, y0: 0.800, y1: 0.823 },
+    HudRow { id: HoverId::ParamNitro, y0: 0.823, y1: 0.846 },
+    HudRow { id: HoverId::ParamAuto, y0: 0.846, y1: 0.869 },
+    HudRow { id: HoverId::ParamPersist, y0: 0.869, y1: 0.892 },
+    HudRow { id: HoverId::ParamMaint, y0: 0.892, y1: 0.915 },
+    HudRow { id: HoverId::ParamEnzyme, y0: 0.915, y1: 0.938 },
+    HudRow { id: HoverId::ParamBranch, y0: 0.938, y1: 0.961 },
+    HudRow { id: HoverId::ParamExtend, y0: 0.961, y1: 0.984 },
 ];
 
 struct SchemeRow {
@@ -376,7 +428,7 @@ pub fn pack_overlay(
     if let Some(toast) = nudge {
         if toast.fade > 0.004 {
             pack_nudge(&mut out.chars, toast);
-            nudge_rect = place_nudge(toast.kind, help, scheme_on);
+            nudge_rect = place_nudge(toast, help, scheme_on);
             nudge_fade = toast.fade;
         }
     }
@@ -402,11 +454,11 @@ fn pack_nudge(chars: &mut [u32], toast: &NudgeToast) {
     blit_line(chars, NUDGE_BASE, NUDGE_COLS, 2, &toast.keys);
 }
 
-fn place_nudge(kind: NudgeKind, help: [f32; 4], scheme_on: bool) -> [f32; 4] {
+fn place_nudge(toast: &NudgeToast, help: [f32; 4], scheme_on: bool) -> [f32; 4] {
     let w = 0.268;
     let h = 0.074;
     let mut x = 0.258;
-    let mut y = (kind.row_y() - 0.012).clamp(0.012, 0.984 - h);
+    let mut y = (toast.row_y - 0.012).clamp(0.012, 0.984 - h);
     let mut rect = [x, y, x + w, y + h];
     if scheme_on && rects_overlap(rect, help) {
         x = (help[2] + 0.012).min(0.990 - w);
@@ -563,7 +615,31 @@ fn tip_text(id: HoverId) -> &'static str {
             "Internal carbon the picked tip is carrying (shown times 100). Extension and branching spend this. A starved tip stops growing even if soil food is nearby, until uptake refills it."
         }
         HoverId::Param | HoverId::ParamKeys => {
-            "Live knob 1-8: chemotropism, nitrotropism, autotropism, persistence, maintenance, enzyme_k, branch cost, extension. Keys 1-8 select the slot. Minus and equals nudge, or drag the framed slider. A toast shows the name, value, and keys while you tweak."
+            "Eight live knobs, each with its own left-HUD slider: chemotropism, nitrotropism, autotropism, persistence, maintenance, enzyme_k, branch cost, extension. Keys 1-8 select and focus. Minus and equals nudge the selected slot. Drag any track to set that value and select it."
+        }
+        HoverId::ParamChemo => {
+            "Chemotropism steers each tip toward soluble carbon, the rust SOL C field. High: tips hunt food plumes and bend hard toward litter. Low: they ignore C gradients and wander or follow persistence, nitrogen, or autotropism instead. Key 1. Drag the track or use minus and equals."
+        }
+        HoverId::ParamNitro => {
+            "Nitrotropism pulls tips toward soluble nitrogen (SOL N). High: tips, especially when reserve is low, chase N plumes, useful in an N-poor pedon. Low: nitrogen barely steers, so a tip may linger in C-rich, N-poor soil. The pull eases as the pantry fills. Key 2."
+        }
+        HoverId::ParamAuto => {
+            "Autotropism turns a tip away from its own trail and nearby biomass (autocrine plus hypha). High: tips avoid crowding, fan into empty soil, and recross old mycelium less. Low: they may pile onto existing hyphae. This is keep-off-the-old-network, not food seeking. Key 3."
+        }
+        HoverId::ParamPersist => {
+            "Persistence keeps the current heading versus turning to tropisms. High: long straight runs; the tip commits and only slowly bends. Low: twitchy steering, yanked by every nearby C, N, or self gradient. High persist plus high chemo still hunts, but in smoother arcs. Key 4."
+        }
+        HoverId::ParamMaint => {
+            "Maintenance is the carbon living biomass burns just to stay alive, even when not growing. High: the network is expensive; cords and hyphae drain internal C and can thin if unfed. Low: cheap upkeep, so a colony banks reserve and survives lean soil. A tax on existing walls, not tip steps. Key 5."
+        }
+        HoverId::ParamEnzyme => {
+            "Enzyme_k scales how fast leaked exoenzyme cuts ORGANIC polymer into soluble C and N. High: litter unlocks quickly; SOL C and SOL N rise while the brown ORGANIC bar falls. Low: enzyme sits on uncleaved polymer and the meal stays wrapped. Outside digestion, not uptake at the tip. Key 6."
+        }
+        HoverId::ParamBranch => {
+            "Branch cost is how much internal reserve a tip must hold before it can birth a side tip. High: forks are expensive; fewer branches, longer unbranched runs. Low: cheap forks, denser trees, more tips hunting litter, and more carbon spent on new heads. Watch the BRANCHES census. Key 7."
+        }
+        HoverId::ParamExtend => {
+            "Extension (max_extension) is how far a tip steps each tick when it has reserve. High: fast explorers that cover voxels quickly, but they can overshoot food and spend reserve faster. Low: short cautious steps; the colony creeps. Starved tips still take shorter steps. Key 8."
         }
         HoverId::Help => {
             "H toggles this corner control-scheme panel, always, including in capture. It never writes a heightmap. Hover a row here, or a left HUD meter, for a teach callout on a white string."
@@ -593,7 +669,7 @@ fn tip_text(id: HoverId) -> &'static str {
             "Hold Shift to coarsen slice depth, thickness, zoom, and pan. In capture, Shift+wheel also grows cutter thickness. It is a modifier, not a mode."
         }
         HoverId::Nudge => {
-            "Minus and equals (or underscore / plus) nudge the selected PARAM slot. Use 1-8 first to choose which rule you are tuning."
+            "Minus and equals (or underscore / plus) nudge the selected PARAM slot. Use 1-8 first, or drag any of the eight left-HUD sliders to select that rule and set its value."
         }
         HoverId::Tab => {
             "Tab cycles label density: rich (full English names), sparse (names on hover or pick), then off (boxes, bars, and small digits only). Hover teach still works in off because the boxes stay hit-testable."
@@ -669,8 +745,10 @@ mod tests {
         let (id, anchor) = hit_test((0.04, 0.110), false, false, false);
         assert_eq!(id, HoverId::Tips);
         assert!((anchor[0] - HUD_X1).abs() < 1e-5);
-        let (id, _) = hit_test((0.04, 0.910), false, false, false);
-        assert_eq!(id, HoverId::Param);
+        let (id, _) = hit_test((0.04, 0.811), false, false, false);
+        assert_eq!(id, HoverId::ParamChemo);
+        let (id, _) = hit_test((0.04, 0.972), false, false, false);
+        assert_eq!(id, HoverId::ParamExtend);
         let (id, _) = hit_test((0.40, 0.110), false, false, false);
         assert_eq!(id, HoverId::None);
     }
@@ -705,6 +783,16 @@ mod tests {
         assert!(wrap_text(tip_text(HoverId::Param), TIP_COLS).len() <= TIP_ROWS);
         assert!(wrap_text(tip_text(HoverId::ExportFormat), TIP_COLS).len() <= TIP_ROWS);
         assert!(wrap_text(tip_text(HoverId::ExportHeightmap), TIP_COLS).len() <= TIP_ROWS);
+        for slot in 0..8u32 {
+            let id = param_hover(slot);
+            let n = wrap_text(tip_text(id), TIP_COLS).len();
+            assert!(n <= TIP_ROWS, "param {slot} teach wraps to {n} lines");
+            let text = tip_text(id);
+            assert!(
+                text.contains("High:") && text.contains("Low:"),
+                "param {slot} must explain high vs low"
+            );
+        }
     }
 
     #[test]
@@ -734,6 +822,7 @@ mod tests {
             value: "1.06 TO 1.10".into(),
             keys: NudgeKind::Param.keys().into(),
             fade: 1.0,
+            row_y: param_row_mid(0),
         };
         let gpu = pack_overlay(
             false,
@@ -757,11 +846,27 @@ mod tests {
         assert_eq!(hud_slider_at((0.16, 0.570)), Some(HudSlider::SliceZ));
         assert_eq!(hud_slider_at((0.16, 0.610)), Some(HudSlider::Thick));
         assert_eq!(hud_slider_at((0.16, 0.650)), Some(HudSlider::Zoom));
-        assert_eq!(hud_slider_at((0.16, 0.910)), Some(HudSlider::Param));
+        assert_eq!(hud_slider_at((0.16, 0.811)), Some(HudSlider::Param(0)));
+        assert_eq!(hud_slider_at((0.16, 0.972)), Some(HudSlider::Param(7)));
         assert!(hud_slider_at((0.16, 0.110)).is_none());
-        assert!(hud_slider_at((0.40, 0.910)).is_none());
+        assert!(hud_slider_at((0.40, 0.811)).is_none());
         assert!((slider_t(SLIDER_TRACK_X0) - 0.0).abs() < 1e-5);
         assert!((slider_t(SLIDER_TRACK_X1) - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn eight_param_rows_pack_under_tip_block() {
+        assert!((TIP_BLOCK_Y1 - TIP_BLOCK_Y0 - 4.0 * TIP_ROW_H).abs() < 1e-5);
+        assert!((PARAM_BLOCK_Y1 - PARAM_BLOCK_Y0 - 8.0 * PARAM_ROW_H).abs() < 1e-5);
+        assert!(TIP_BLOCK_Y1 <= PARAM_BLOCK_Y0 + 1e-5);
+        assert!(PARAM_BLOCK_Y1 <= 0.990);
+        for slot in 0..8u32 {
+            let (y0, y1) = param_row(slot);
+            let mid = 0.5 * (y0 + y1);
+            assert_eq!(hud_slider_at((0.16, mid)), Some(HudSlider::Param(slot as u8)));
+            let (id, _) = hit_test((0.04, mid), false, false, false);
+            assert_eq!(id, param_hover(slot));
+        }
     }
 
     #[test]

--- a/pycelium-win/src/types.rs
+++ b/pycelium-win/src/types.rs
@@ -125,6 +125,20 @@ impl SimUniforms {
         }
     }
 
+    /// Short left-HUD caption. Must stay in lockstep with `present.wgsl` label ids 32–39.
+    pub fn param_hud_label(slot: u32) -> &'static str {
+        match slot % 8 {
+            0 => "CHEMO",
+            1 => "NITRO",
+            2 => "AUTO",
+            3 => "PERSIST",
+            4 => "MAINT",
+            5 => "ENZYME_K",
+            6 => "BRANCH",
+            _ => "EXTEND",
+        }
+    }
+
     /// Inclusive knob range. Must stay in lockstep with `present.wgsl` `param_fill`.
     pub fn param_range(slot: u32) -> (f32, f32) {
         match slot % 8 {
@@ -230,6 +244,8 @@ pub struct PresentUniforms {
     pub callout: [f32; 4],
     /// Live nudge toast UV rect (x0,y0,x1,y1).
     pub nudge_rect: [f32; 4],
+    /// Normalized 0..1 fills for the eight left-HUD param sliders.
+    pub param_fills: [f32; 8],
 }
 
 /// Orthogonal section through the pedon. Depth is the plane; thickness is
@@ -323,7 +339,17 @@ mod tests {
     fn present_uniforms_stay_16_byte_aligned() {
         assert_eq!(std::mem::size_of::<PresentUniforms>() % 16, 0);
         assert!(std::mem::size_of::<PresentUniforms>() >= 176);
-        assert_eq!(std::mem::size_of::<PresentUniforms>(), 16 * 17);
+        assert_eq!(std::mem::size_of::<PresentUniforms>(), 16 * 19);
+    }
+
+    #[test]
+    fn param_hud_labels_fit_eight_glyphs() {
+        for slot in 0..8 {
+            assert!(SimUniforms::param_hud_label(slot).len() <= 8);
+        }
+        assert_eq!(SimUniforms::param_hud_label(0), "CHEMO");
+        assert_eq!(SimUniforms::param_hud_label(5), "ENZYME_K");
+        assert_eq!(SimUniforms::param_hud_label(7), "EXTEND");
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Replaces the single PARAM row from #8 with **eight dedicated left-HUD sliders**, one per tunable slot.

## Layout

The left column is already dense. Census, field bars, and SLICE Z / THICK / ZOOM stay on their existing UV rows so those sliders and hit-tests do not move. The selected-tip block is tightened, and the eight knobs share **one group frame** with compact tracks (no scroll).

| Key | Label | Sim name |
|-----|-------|----------|
| 1 | CHEMO | chemotropism |
| 2 | NITRO | nitrotropism |
| 3 | AUTO | autotropism |
| 4 | PERSIST | persistence |
| 5 | MAINT | maintenance |
| 6 | ENZYME_K | enzyme_k |
| 7 | BRANCH | branch_cost |
| 8 | EXTEND | extension |

House chrome is unchanged: thin white frames, 1–2 px pixelated shadows, color readout boxes. Tab rich / sparse / off still applies; sliders stay drawn like field bars, and sparse keeps the **selected** caption lit (plus hover).

## Interaction

- Keys **1–8** select / focus that row
- **-/=** nudges the selected slot
- Dragging any track sets that slot’s value **and** selects it
- Live nudge toast + in-context key reminder (`1-8 SELECT  -/= NUDGE`) still fire on key or drag

## Teach

Hover each of the eight rows for a learner-facing popup that states **what a high value does vs a low value** (tropisms, persistence, maintenance tax, enzyme kinetics, branch cost, extension rate). The H control-scheme panel, export card, and slice sliders are untouched.

## Docs / tests

- `docs/HUD_LEGEND.md` (brief), README
- `cargo test -p pycelium-win` should pass
- GPU window was **not** visually verified in this environment

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07a8d7cb-ae37-44e9-8e20-c0ebd1b04774?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07a8d7cb-ae37-44e9-8e20-c0ebd1b04774&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

