### PR TITLE
Species strip, specimen inoculate, and GPU field paint

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ python pycelium.py
 
 ### GPU mesocosm (`pycelium-win`)
 
-Windows / wgpu 3D pedon. Left telemetry HUD uses **white sans-serif English** plus a color readout box per row (rich by default; **Tab** cycles rich / sparse / off). Adjustable meters (**SLICE Z**, **THICK**, **ZOOM**, and the eight **PARAM** knobs) have framed sliders; tweak keys show a short toast with the name, value, and binds. **H** toggles a corner control-scheme panel; hover a meter for a teach callout. Small 3×5 digits stay on the right. Legend: [docs/HUD_LEGEND.md](docs/HUD_LEGEND.md). Face-aligned **slice export** (`E` capture, `S` settings, `Enter` write PNG/JSON/SVG) defaults to a **512×512** power-of-two square (presets 8…8192): [docs/SLICE_EXPORT.md](docs/SLICE_EXPORT.md). Heightmap write is **M**.
+Windows / wgpu 3D pedon. Left telemetry HUD uses **white sans-serif English** plus a color readout box per row (rich by default; **Tab** cycles rich / sparse / off). Adjustable meters (**SLICE Z**, **THICK**, **ZOOM**, and the eight **PARAM** knobs) have framed sliders; tweak keys show a short toast with the name, value, and binds. **H** toggles a corner control-scheme panel; hover a meter for a teach callout. A top-center **species strip** (eight squares) arms specimen inoculate or field paint: [docs/PAINT.md](docs/PAINT.md). Small 3×5 digits stay on the right. Legend: [docs/HUD_LEGEND.md](docs/HUD_LEGEND.md). Face-aligned **slice export** (`E` capture, `S` settings, `Enter` write PNG/JSON/SVG) defaults to a **512×512** power-of-two square (presets 8…8192): [docs/SLICE_EXPORT.md](docs/SLICE_EXPORT.md). Heightmap write is **M**.
 
 ```bash
 cargo run -p pycelium-win --release -- --preset demo
 # Tab: label density    H: control scheme    hover a meter for a teach callout
+# T: specimen/paint    click a species square    1-8 slot    9/0 brush    Alt erase
 # E: capture slice    S: export size (8…8K square)    C: 2D/rich    M: heightmap    Enter: export
 # --bench N is headless and does not open the HUD
 ```
@@ -46,6 +47,7 @@ labeled **EXAMPLE** and are not measurements.
 | `pycelium.py` | CLI toy |
 | `pycelium-win/` | GPU mesocosm + telemetry HUD |
 | `docs/HUD_LEGEND.md` | Left HUD map (glyphs + English) |
+| `docs/PAINT.md` | Species presets, inoculate, field paint |
 | `docs/SLICE_EXPORT.md` | Capture cutter + export formats |
 | `docs/EXPERIMENT_LOG.md` | How to record a logged trial |
 | `docs/experiments/` | CSV / JSONL schema + EXAMPLE rows |

--- a/docs/HUD_LEGEND.md
+++ b/docs/HUD_LEGEND.md
@@ -62,7 +62,13 @@ Click in the volume to pick the nearest live tip. `hud[10]` is the pick distance
 | 0.75 | ice | `AGE` | 5 | tip age |
 | 0.77 | amber | `RESERVE` | 4 | internal reserve × 100 |
 
-After a pick, sparse mode keeps this block readable.
+After a pick, sparse mode keeps this block readable. Painted inocula use lineage 1–8 (the species strip) and `flags = 2`.
+
+## Species strip + paint (top center)
+
+Eight square buttons sit between the left HUD and the slab inset (`docs/PAINT.md`). A colored glyph and a four-letter name mark each starter species. **SPEC** / **PAINT** chips sit to the right of the row.
+
+Selecting a square writes the eight PARAM knobs for that species and arms the specimen brush. Click-drag in the volume inoculates tips (or, in PAINT, writes field buffers). `T` cycles VIEW / SPECIMEN / PAINT. In VIEW, `1–8` still select PARAM rows; in the other tools they select species or paint channel. `9` / `0` (or wheel while armed) change brush radius. Alt subtracts. Hover a square for species-bias teach copy; a toast reports the current tool.
 
 ## Param knobs (compact group, shared frame)
 
@@ -94,6 +100,8 @@ Heightmap PNG write in capture is **M**, not H. **Y** still cycles the heightmap
 ## Inset (right)
 
 The orthogonal slab inset is **not** part of the left HUD. It shows hypha + soluble C in the current Z slab, framed, with zoom/pan.
+
+The species strip sits **above** the inset, left of `x = 0.72`, so it does not fight the left meters or the capture thickness slider.
 
 ## Controls that do not change presets
 

--- a/docs/PAINT.md
+++ b/docs/PAINT.md
@@ -1,0 +1,78 @@
+# Species presets, inoculate, and field paint
+
+Lab tools for the GPU mesocosm (`pycelium-win`). Not a game brush. Stamps write the **same storage buffers** the sim already marches: tips, soluble C/N, moisture, organic, enzyme, biomass.
+
+House chrome: top-center strip of eight square species buttons (colored glyph + short name), plus **SPEC** / **PAINT** chips. Hover a square for a teach callout. A toast (same family as the PARAM nudge) shows tool, species or channel, and brush radius.
+
+See also [HUD_LEGEND.md](HUD_LEGEND.md).
+
+## Tools
+
+| Mode | Arm | Left-drag in the box | 1–8 |
+|------|-----|----------------------|-----|
+| **VIEW** | `T` until VIEW, or start | Orbit; release picks the nearest live tip | PARAM knobs (unchanged) |
+| **SPECIMEN** | Click a species square, SPEC chip, or `T` | Inoculate germ tubes of that lineage | Select species + write its eight knobs |
+| **PAINT** | PAINT chip or `T` | Deposit / subtract a field channel | Select channel |
+
+- **Right-drag** always orbits (so the left button can stamp).
+- **9 / 0** shrink / grow brush radius (Shift = coarse). Wheel does the same while a tool is armed, or while the cursor is on the strip. In VIEW the wheel still dollies.
+- **Alt** subtracts: kill tips of the selected lineage (specimen), or remove the armed channel (paint).
+- Capture (`E`) keeps the mouse for the cutter; stamps do not fire.
+
+The stamp lands at the **ray–cube midpoint**, the same depth rule as the capture cutter — inside the volume, not only on the face.
+
+## Eight starter species
+
+Selecting a square **arms the specimen brush** and writes the eight global PARAM knobs. Those knobs are still shared by every live tip (no per-lineage genome yet). Painted inocula set `Tip.lineage` to 1…8 and `Tip.flags = 2` so a later genetics pass can tell them from the startup handful (`flags = 0`) and `grow()` branches (`flags = 1`).
+
+| # | Name | Short | Color | Lineage | Bias |
+|---|------|-------|-------|---------|------|
+| 1 | Pioneer | PION | ice teal | 1 | High chemo + extension, cheap forks, twitchy |
+| 2 | Cord-former | CORD | amber | 2 | High persist + extension, expensive branches |
+| 3 | Scavenger | SCAV | rust | 3 | High enzyme_k + chemo; litter miner |
+| 4 | Nitrophile | NITR | violet | 4 | High nitrotropism, ignores C plumes |
+| 5 | Mat-former | MAT | green | 5 | Low auto / persist, cheap forks, dense fill |
+| 6 | Thrifty | THRF | gold | 6 | Very low maintenance, cautious steps |
+| 7 | Ranger | RANG | coral | 7 | Long hunting arcs: chemo + persist + auto + extend |
+| 8 | Miner | MINE | ice | 8 | Costly aggressive metabolizer (antagonism hook) |
+
+Startup germ tubes still use inoculum sites 1–5 (`model.rs`). They are not these named presets.
+
+**Extension hook:** antagonism / per-tip genes should read `lineage` and `flags` rather than inventing a second id. Do not treat Miner as chemical warfare — it is flavor plus a costly enzyme/maintenance mix.
+
+## Paint channels
+
+`1–8` in PAINT mode. All writes are GPU compute on a small AABB around the stamp (radius-bounded), not a full-volume pass.
+
+| # | Channel | Buffer(s) |
+|---|---------|-----------|
+| 1 | SOL C | `soluble_c` |
+| 2 | SOL N | `soluble_n` |
+| 3 | H2O | `moisture` (gates enzyme + diffusion) |
+| 4 | ORG | `organic` polymer |
+| 5 | ENZ | `enzyme` |
+| 6 | WOOD | organic + a little soluble C (woody litter) |
+| 7 | LITTER | organic + soluble N (+ a touch of C) |
+| 8 | VOID | cutout: scales down biomass, organic, soluble C/N, enzyme, internal C, and kills tips in the brush |
+
+There is **no dedicated poison field**. VOID is a subtractive stamp on existing buffers. Moisture is real and already used in `kinetics` / `diffuse`; it is not drawn as a left-HUD bar yet.
+
+## Performance
+
+- Field stamps dispatch `(2r+2)³` threads in 8×8×4 groups. Default radius is 5 voxels; max 24.
+- Inoculate walks tip slots once, claims at most six dormant **parent-half** slots (`id < tip_count/2`) so `grow()` keeps its branch pool.
+- Strokes skip samples closer than `0.4 × radius`.
+
+Target box remains an RTX 3060-class card. `--bench` never opens a window and does not exercise the strip.
+
+## Keys (additive)
+
+| Key | Action |
+|-----|--------|
+| `T` | Cycle VIEW → SPECIMEN → PAINT |
+| Click square | Arm that species + specimen tool |
+| `1–8` | VIEW: param. SPECIMEN: species. PAINT: channel |
+| `9` `0` | Brush radius |
+| Alt | Erase / subtract |
+| Right-drag | Orbit |
+| Wheel | Dolly in VIEW; radius when a tool is armed |

--- a/pycelium-win/src/cutter.rs
+++ b/pycelium-win/src/cutter.rs
@@ -293,6 +293,12 @@ fn axis_component(p: [f32; 3], axis: Axis) -> f32 {
     }
 }
 
+/// Midpoint of the ray–cube segment, in unit-cube space.
+pub fn ray_cube_midpoint(ro: [f32; 3], rd: [f32; 3]) -> Option<[f32; 3]> {
+    let seg = ray_cube_segment(ro, rd)?;
+    Some(segment_midpoint(ro, rd, seg))
+}
+
 fn segment_midpoint(ro: [f32; 3], rd: [f32; 3], seg: (f32, f32)) -> [f32; 3] {
     let t = 0.5 * (seg.0.max(0.0) + seg.1);
     [
@@ -462,6 +468,9 @@ mod tests {
         assert!((seg.0 - 1.0).abs() < 1e-4);
         assert!((seg.1 - 2.0).abs() < 1e-4);
         assert!(ray_cube_segment([-2.0, 2.0, 0.5], [1.0, 0.0, 0.0]).is_none());
+        let mid = ray_cube_midpoint([-1.0, 0.5, 0.5], [1.0, 0.0, 0.0]).unwrap();
+        assert!((mid[0] - 0.5).abs() < 1e-4);
+        assert!((mid[1] - 0.5).abs() < 1e-4);
     }
 
     #[test]

--- a/pycelium-win/src/gpu.rs
+++ b/pycelium-win/src/gpu.rs
@@ -91,6 +91,8 @@ pub struct MyceliumGpu {
     grow: wgpu::ComputePipeline,
     hud_reduce: wgpu::ComputePipeline,
     pick: wgpu::ComputePipeline,
+    paint: wgpu::ComputePipeline,
+    inoculate: wgpu::ComputePipeline,
     sim_bg: wgpu::BindGroup,
     present_pipeline: wgpu::RenderPipeline,
     present_bg: wgpu::BindGroup,
@@ -373,6 +375,8 @@ impl MyceliumGpu {
             grow: compute("grow"),
             hud_reduce: compute("hud_reduce"),
             pick: compute("pick"),
+            paint: compute("paint"),
+            inoculate: compute("inoculate"),
             sim_bg,
             present_pipeline,
             present_bg,
@@ -436,6 +440,51 @@ impl MyceliumGpu {
         self.uniforms.set_normalized(self.param_slot, t);
     }
 
+    /// GPU stamp: inoculate (mode 1), erase tips (2), paint add (3), paint subtract (4).
+    /// `kill_tips` runs a second erase pass (lineage 0 = any) after a field stamp.
+    pub fn stamp_brush(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        center: [f32; 3],
+        radius: f32,
+        strength: f32,
+        channel: u32,
+        lineage: u32,
+        mode: u32,
+        kill_tips: bool,
+    ) {
+        self.uniforms.brush_x = center[0];
+        self.uniforms.brush_y = center[1];
+        self.uniforms.brush_z = center[2];
+        self.uniforms.brush_radius = radius.max(0.75);
+        self.uniforms.brush_strength = strength.clamp(0.05, 1.5);
+        self.uniforms.brush_channel = channel as f32;
+        self.uniforms.brush_lineage = lineage as f32;
+        self.uniforms.brush_mode = mode as f32;
+        self.uniforms.seed = self.uniforms.seed.wrapping_add(1);
+
+        if mode == 1 || mode == 2 {
+            let zero = 0u32;
+            queue.write_buffer(&self.tel, 12 * 4, bytemuck::bytes_of(&zero));
+            self.dispatch_named(device, queue, "inoculate");
+        }
+        if mode == 3 || mode == 4 {
+            self.dispatch_named(device, queue, "paint");
+            if kill_tips {
+                let prev_lin = self.uniforms.brush_lineage;
+                self.uniforms.brush_mode = 2.0;
+                self.uniforms.brush_lineage = 0.0;
+                let zero = 0u32;
+                queue.write_buffer(&self.tel, 12 * 4, bytemuck::bytes_of(&zero));
+                self.dispatch_named(device, queue, "inoculate");
+                self.uniforms.brush_lineage = prev_lin;
+            }
+        }
+        self.uniforms.brush_mode = 0.0;
+        queue.write_buffer(&self.uniform_buf, 0, bytemuck::bytes_of(&self.uniforms));
+    }
+
     pub fn upload_brick(&self, queue: &wgpu::Queue, world: &HostWorld) {
         let brick = world.extract_brick(self.width, self.height, self.depth);
         queue.write_buffer(&self.organic, 0, bytemuck::cast_slice(&brick.organic));
@@ -473,6 +522,8 @@ impl MyceliumGpu {
         cutter: [f32; 4],
         export_ui: [f32; 4],
         overlay: &OverlayGpu,
+        brush_ui: [f32; 4],
+        brush_hit: [f32; 4],
     ) {
         let present = PresentUniforms {
             width: self.width,
@@ -523,6 +574,8 @@ impl MyceliumGpu {
             tip_rect: overlay.tip_rect,
             callout: overlay.callout,
             nudge_rect: overlay.nudge_rect,
+            brush_ui,
+            brush_hit,
         };
         queue.write_buffer(&self.present_buf, 0, bytemuck::bytes_of(&present));
         queue.write_buffer(&self.overlay_buf, 0, bytemuck::cast_slice(&overlay.chars));
@@ -596,9 +649,23 @@ impl MyceliumGpu {
             });
             pass.set_bind_group(0, &self.sim_bg, &[]);
             match name {
-                "grow" | "pick" => {
-                    pass.set_pipeline(if name == "grow" { &self.grow } else { &self.pick });
+                "grow" | "pick" | "inoculate" => {
+                    pass.set_pipeline(match name {
+                        "grow" => &self.grow,
+                        "pick" => &self.pick,
+                        _ => &self.inoculate,
+                    });
                     pass.dispatch_workgroups(self.tip_count.div_ceil(TIP_WG), 1, 1);
+                }
+                "paint" => {
+                    pass.set_pipeline(&self.paint);
+                    let r = (self.uniforms.brush_radius.ceil() as u32 + 2).max(2);
+                    let edge = (2 * r + 2).max(8);
+                    pass.dispatch_workgroups(
+                        edge.div_ceil(VOL_X),
+                        edge.div_ceil(VOL_Y),
+                        edge.div_ceil(VOL_Z),
+                    );
                 }
                 other => {
                     let pipe = match other {
@@ -673,6 +740,17 @@ mod shader_tests {
         validator
             .validate(&module)
             .expect("present.wgsl should validate");
+    }
+
+    #[test]
+    fn sim_wgsl_parses_and_validates() {
+        let src = include_str!("shaders/sim.wgsl");
+        let module = naga::front::wgsl::parse_str(src).expect("parse sim.wgsl");
+        let mut validator = naga::valid::Validator::new(
+            naga::valid::ValidationFlags::all(),
+            naga::valid::Capabilities::default(),
+        );
+        validator.validate(&module).expect("sim.wgsl should validate");
     }
 }
 

--- a/pycelium-win/src/main.rs
+++ b/pycelium-win/src/main.rs
@@ -6,6 +6,7 @@ mod gpu;
 mod hud_font;
 mod memory;
 mod model;
+mod species;
 mod teach;
 mod types;
 
@@ -23,11 +24,12 @@ use winit::keyboard::{Key, NamedKey};
 use winit::window::{Window, WindowId};
 
 use crate::config::{Args, LabelDensity, MemoryPlan};
-use crate::cutter::Cutter;
+use crate::cutter::{ray_cube_midpoint, Cutter};
 use crate::export::{apply_export_layout, extract_slice, utc_stamp, write_exports_with_meta};
 use crate::export_settings::ExportSettings;
 use crate::gpu::{GpuDevice, MyceliumGpu};
 use crate::memory::HostWorld;
+use crate::species::{strip_hit, BrushState, PaintChannel, StripHit, ToolMode};
 use crate::teach::{HoverId, HudSlider, NudgeKind, NudgeToast};
 use crate::types::SimUniforms;
 
@@ -84,6 +86,8 @@ struct Runtime {
     last_hover: HoverId,
     nudge: Option<LiveNudge>,
     hud_drag: Option<HudDrag>,
+    brush: BrushState,
+    alt: bool,
 }
 
 struct LiveNudge {
@@ -256,6 +260,8 @@ impl ApplicationHandler<AppAction> for App {
                 last_hover: HoverId::None,
                 nudge: None,
                 hud_drag: None,
+                brush: BrushState::default(),
+                alt: false,
             })));
         });
     }
@@ -286,6 +292,9 @@ impl ApplicationHandler<AppAction> for App {
                     "HUD: FPS, tips, fusions, branches, C:N | bars | then slice Z / thickness / zoom% | selected tip"
                 );
                 println!("H control scheme | hover a meter or scheme row for a teach callout");
+                println!(
+                    "T specimen/paint | click a species square | 1-8 slot | 9/0 brush | Alt erase | right-drag orbit"
+                );
             }
         }
     }
@@ -323,6 +332,10 @@ impl ApplicationHandler<AppAction> for App {
                     apply_hud_slider(rt, drag.slider, rt.cursor.0, &drag.start);
                     rt.window.request_redraw();
                 }
+                if rt.brush.stroking && !rt.cutter.active && rt.hud_drag.is_none() {
+                    try_stamp_brush(rt);
+                    rt.window.request_redraw();
+                }
                 if rt.cutter.active {
                     let axis_n = rt.cutter.axis.size(rt.sim.width, rt.sim.height, rt.sim.depth)
                         as f32;
@@ -345,6 +358,14 @@ impl ApplicationHandler<AppAction> for App {
                 }
             }
             WindowEvent::MouseInput { state, button, .. } => {
+                if button == MouseButton::Right {
+                    rt.orbit.dragging = state == ElementState::Pressed;
+                    rt.orbit.last = None;
+                    if state == ElementState::Released {
+                        rt.brush.stroking = false;
+                    }
+                    return;
+                }
                 if button == MouseButton::Left {
                     let scheme_rect = teach::scheme_rect(rt.export.panel_open && rt.cutter.active);
                     if rt.scheme_visible && teach::in_rect(rt.cursor, scheme_rect) {
@@ -353,6 +374,13 @@ impl ApplicationHandler<AppAction> for App {
                         return;
                     }
                     if state == ElementState::Pressed {
+                        if let Some(hit) = strip_hit(rt.cursor) {
+                            apply_strip_hit(rt, hit);
+                            rt.orbit.dragging = false;
+                            rt.orbit.last = None;
+                            rt.window.request_redraw();
+                            return;
+                        }
                         if let Some(slider) = teach::hud_slider_at(rt.cursor) {
                             let start = match slider {
                                 HudSlider::SliceZ => fmt_slice_z(rt.sim.slice.z),
@@ -440,6 +468,25 @@ impl ApplicationHandler<AppAction> for App {
                         rt.orbit.last = None;
                         return;
                     }
+                    let tool_draw = !rt.cutter.active
+                        && rt.brush.mode != ToolMode::View
+                        && rt.hud_drag.is_none();
+                    if tool_draw {
+                        if state == ElementState::Pressed {
+                            rt.brush.stroking = true;
+                            rt.brush.last_stamp = None;
+                            rt.orbit.dragging = false;
+                            rt.orbit.last = None;
+                            try_stamp_brush(rt);
+                        } else {
+                            rt.brush.stroking = false;
+                            rt.brush.last_stamp = None;
+                            rt.orbit.dragging = false;
+                            rt.orbit.last = None;
+                        }
+                        rt.window.request_redraw();
+                        return;
+                    }
                     rt.orbit.dragging = state == ElementState::Pressed;
                     rt.orbit.last = None;
                     if state == ElementState::Released && !rt.cutter.active {
@@ -460,6 +507,13 @@ impl ApplicationHandler<AppAction> for App {
                     let axis_n = rt.cutter.axis.size(rt.sim.width, rt.sim.height, rt.sim.depth)
                         as f32;
                     rt.cutter.nudge_half(steps * if rt.shift { 2.0 } else { 1.0 }, axis_n);
+                } else if !rt.cutter.active
+                    && (rt.brush.mode != ToolMode::View || strip_hit(rt.cursor).is_some())
+                {
+                    let step = if rt.shift { 2.4 } else { 0.8 };
+                    rt.brush.nudge_radius(steps * step);
+                    fire_brush_toast(rt);
+                    rt.window.request_redraw();
                 } else {
                     rt.orbit.radius = (rt.orbit.radius - steps * 0.12).clamp(0.55, 4.5);
                 }
@@ -476,6 +530,15 @@ impl ApplicationHandler<AppAction> for App {
             } => {
                 if matches!(logical_key, Key::Named(NamedKey::Shift)) {
                     rt.shift = state == ElementState::Pressed;
+                    return;
+                }
+                if matches!(logical_key, Key::Named(NamedKey::Alt)) {
+                    rt.alt = state == ElementState::Pressed;
+                    rt.brush.erase = rt.alt;
+                    if rt.brush.mode != ToolMode::View {
+                        fire_brush_toast(rt);
+                        rt.window.request_redraw();
+                    }
                     return;
                 }
                 if state != ElementState::Pressed {
@@ -582,6 +645,17 @@ impl ApplicationHandler<AppAction> for App {
                     rt.window.request_redraw();
                     return;
                 }
+                let radius_nudge = match &logical_key {
+                    Key::Character(c) if c == "9" => Some(if rt.shift { -2.4 } else { -0.8 }),
+                    Key::Character(c) if c == "0" => Some(if rt.shift { 2.4 } else { 0.8 }),
+                    _ => None,
+                };
+                if let Some(delta) = radius_nudge {
+                    rt.brush.nudge_radius(delta);
+                    fire_brush_toast(rt);
+                    rt.window.request_redraw();
+                    return;
+                }
                 if repeat {
                     return;
                 }
@@ -675,6 +749,12 @@ impl ApplicationHandler<AppAction> for App {
                         rt.cutter.export_heightmap = true;
                         println!("{}", rt.cutter.describe());
                     }
+                    Key::Character(c) if c.eq_ignore_ascii_case("t") && !rt.cutter.active => {
+                        rt.brush.cycle_mode();
+                        fire_brush_toast(rt);
+                        println!("tool {}", rt.brush.mode.as_str());
+                        rt.window.request_redraw();
+                    }
                     Key::Named(NamedKey::Space) => rt.paused = !rt.paused,
                     Key::Character(c) if c.eq_ignore_ascii_case("r") => {
                         rt.sim.reseed(&rt.gpu.queue, &rt.world);
@@ -689,23 +769,42 @@ impl ApplicationHandler<AppAction> for App {
                     Key::Character(c) => {
                         if let Some(d) = c.chars().next().and_then(|ch| ch.to_digit(10)) {
                             if (1..=8).contains(&d) {
-                                rt.sim.param_slot = d - 1;
-                                let v = fmt_param(
-                                    rt.sim.param_slot,
-                                    rt.sim.uniforms.param_value(rt.sim.param_slot),
-                                );
-                                fire_nudge(
-                                    rt,
-                                    NudgeKind::Param,
-                                    param_title(rt.sim.param_slot),
-                                    v.clone(),
-                                    v.clone(),
-                                );
-                                println!(
-                                    "param {} = {:.4}",
-                                    SimUniforms::param_name(rt.sim.param_slot),
-                                    rt.sim.uniforms.param_value(rt.sim.param_slot)
-                                );
+                                let slot = (d - 1) as u8;
+                                match rt.brush.mode {
+                                    ToolMode::Specimen => {
+                                        rt.brush.select_species(slot, &mut rt.sim.uniforms);
+                                        fire_brush_toast(rt);
+                                        println!(
+                                            "species {} lineage {}",
+                                            rt.brush.species_preset().name,
+                                            rt.brush.species_preset().lineage
+                                        );
+                                    }
+                                    ToolMode::Paint => {
+                                        rt.brush.select_channel(PaintChannel::from_index(slot));
+                                        fire_brush_toast(rt);
+                                        println!("paint {}", rt.brush.channel.name());
+                                    }
+                                    ToolMode::View => {
+                                        rt.sim.param_slot = slot as u32;
+                                        let v = fmt_param(
+                                            rt.sim.param_slot,
+                                            rt.sim.uniforms.param_value(rt.sim.param_slot),
+                                        );
+                                        fire_nudge(
+                                            rt,
+                                            NudgeKind::Param,
+                                            param_title(rt.sim.param_slot),
+                                            v.clone(),
+                                            v.clone(),
+                                        );
+                                        println!(
+                                            "param {} = {:.4}",
+                                            SimUniforms::param_name(rt.sim.param_slot),
+                                            rt.sim.uniforms.param_value(rt.sim.param_slot)
+                                        );
+                                    }
+                                }
                                 rt.window.request_redraw();
                             }
                         }
@@ -811,6 +910,7 @@ impl ApplicationHandler<AppAction> for App {
                             rt.tip_fade,
                             toast.as_ref(),
                         );
+                        let brush_hit = brush_hit_vec(rt, eye, target);
                         rt.sim.render(
                             &rt.gpu.device,
                             &rt.gpu.queue,
@@ -827,6 +927,8 @@ impl ApplicationHandler<AppAction> for App {
                             rt.cutter.present_vec(),
                             rt.export.present_vec(),
                             &overlay,
+                            rt.brush.present_vec(),
+                            brush_hit,
                         );
                         rt.window.pre_present_notify();
                         rt.gpu.queue.present(frame);
@@ -864,7 +966,13 @@ impl ApplicationHandler<AppAction> for App {
 
     fn about_to_wait(&mut self, _event_loop: &ActiveEventLoop) {
         if let Some(rt) = &self.runtime {
-            if !rt.paused || rt.nudge.is_some() || rt.scheme_fade > 0.01 || rt.tip_fade > 0.01 {
+            if !rt.paused
+                || rt.nudge.is_some()
+                || rt.scheme_fade > 0.01
+                || rt.tip_fade > 0.01
+                || rt.brush.stroking
+                || rt.brush.mode != crate::species::ToolMode::View
+            {
                 rt.window.request_redraw();
             }
         }
@@ -1017,6 +1125,117 @@ fn apply_hud_slider(rt: &mut Runtime, slider: HudSlider, x: f32, start: &str) {
                 fmt_param(rt.sim.param_slot, rt.sim.uniforms.param_value(rt.sim.param_slot)),
             );
         }
+    }
+}
+
+fn apply_strip_hit(rt: &mut Runtime, hit: StripHit) {
+    match hit {
+        StripHit::Species(id) => {
+            rt.brush.select_species(id, &mut rt.sim.uniforms);
+            fire_brush_toast(rt);
+            println!(
+                "species {} lineage {}",
+                rt.brush.species_preset().name,
+                rt.brush.species_preset().lineage
+            );
+        }
+        StripHit::SpecimenMode => {
+            rt.brush.mode = ToolMode::Specimen;
+            rt.brush.apply_species(&mut rt.sim.uniforms);
+            rt.brush.stroking = false;
+            rt.brush.last_stamp = None;
+            fire_brush_toast(rt);
+        }
+        StripHit::PaintMode => {
+            rt.brush.mode = ToolMode::Paint;
+            rt.brush.stroking = false;
+            rt.brush.last_stamp = None;
+            fire_brush_toast(rt);
+        }
+    }
+}
+
+fn fire_brush_toast(rt: &mut Runtime) {
+    fire_nudge(
+        rt,
+        NudgeKind::Brush,
+        rt.brush.toast_title(),
+        rt.brush.toast_value(),
+        rt.brush.toast_value(),
+    );
+}
+
+fn try_stamp_brush(rt: &mut Runtime) {
+    if rt.cutter.active || rt.brush.mode == ToolMode::View {
+        return;
+    }
+    if teach::hud_slider_at(rt.cursor).is_some() || strip_hit(rt.cursor).is_some() {
+        return;
+    }
+    if rt.scheme_visible && teach::in_rect(rt.cursor, teach::scheme_rect(false)) {
+        return;
+    }
+    let (eye, target) = rt.orbit.eye_target();
+    let rd = click_dir(rt.cursor, rt.config.width, rt.config.height, eye, target);
+    let Some(mid) = ray_cube_midpoint(eye, rd) else {
+        return;
+    };
+    let vol = [
+        rt.sim.width as f32,
+        rt.sim.height as f32,
+        rt.sim.depth as f32,
+    ];
+    let center = [mid[0] * vol[0], mid[1] * vol[1], mid[2] * vol[2]];
+    if !rt.brush.should_stamp(center) {
+        return;
+    }
+    rt.brush.last_stamp = Some(center);
+    rt.brush.erase = rt.alt;
+    let lineage = rt.brush.species_preset().lineage;
+    match rt.brush.mode {
+        ToolMode::Specimen => {
+            let mode = if rt.brush.erase { 2 } else { 1 };
+            rt.sim.stamp_brush(
+                &rt.gpu.device,
+                &rt.gpu.queue,
+                center,
+                rt.brush.radius,
+                rt.brush.strength,
+                0,
+                lineage,
+                mode,
+                false,
+            );
+        }
+        ToolMode::Paint => {
+            let subtract = rt.brush.erase || rt.brush.channel == PaintChannel::Void;
+            let mode = if subtract { 4 } else { 3 };
+            let kill = rt.brush.channel == PaintChannel::Void;
+            rt.sim.stamp_brush(
+                &rt.gpu.device,
+                &rt.gpu.queue,
+                center,
+                rt.brush.radius,
+                rt.brush.strength,
+                rt.brush.channel.index() as u32,
+                0,
+                mode,
+                kill,
+            );
+        }
+        ToolMode::View => {}
+    }
+    fire_brush_toast(rt);
+}
+
+fn brush_hit_vec(rt: &Runtime, eye: [f32; 3], target: [f32; 3]) -> [f32; 4] {
+    if rt.brush.mode == ToolMode::View || rt.cutter.active {
+        return [0.0, 0.0, 0.0, 0.0];
+    }
+    let rd = click_dir(rt.cursor, rt.config.width, rt.config.height, eye, target);
+    match ray_cube_midpoint(eye, rd) {
+        Some(p) => [p[0], p[1], p[2], 1.0],
+        None => [0.0, 0.0, 0.0, 0.0],
     }
 }
 

--- a/pycelium-win/src/model.rs
+++ b/pycelium-win/src/model.rs
@@ -14,6 +14,7 @@
 //!    (conductance √(ρᵢρⱼ)). Tips are sinks; food is a source.
 //!
 //! Inoculum is a handful of germ tubes. Time, not particle count, fills the dish.
+//! Painted specimens (`Tip.flags = 2`, lineage 1–8) reuse this tip pool; see `species.rs`.
 
 pub const GERM_TUBES_PER_SPORE: u32 = 72;
 pub const INOCULUM_SITES: u32 = 5;

--- a/pycelium-win/src/shaders/present.wgsl
+++ b/pycelium-win/src/shaders/present.wgsl
@@ -50,6 +50,8 @@ struct PresentUniforms {
     nudge_rect: vec4<f32>,
     params_a: vec4<f32>,
     params_b: vec4<f32>,
+    brush_ui: vec4<f32>,
+    brush_hit: vec4<f32>,
 }
 
 @group(0) @binding(0) var<uniform> u: PresentUniforms;
@@ -65,13 +67,13 @@ struct PresentUniforms {
 @group(0) @binding(10) var<storage, read> overlay: array<u32>;
 
 const HELP_COLS: i32 = 26;
-const HELP_ROWS: i32 = 22;
+const HELP_ROWS: i32 = 25;
 const TIP_COLS: i32 = 36;
 const TIP_ROWS: i32 = 8;
-const TIP_BASE: i32 = 572;
+const TIP_BASE: i32 = 650;
 const NUDGE_COLS: i32 = 28;
 const NUDGE_ROWS: i32 = 3;
-const NUDGE_BASE: i32 = 860;
+const NUDGE_BASE: i32 = 938;
 
 struct VsOut {
     @builtin(position) clip: vec4<f32>,
@@ -350,6 +352,36 @@ fn label_char(id: i32, slot: i32) -> i32 {
         case 39: { // EXTEND
             switch slot { case 0: { return 5; } case 1: { return 24; } case 2: { return 20; } case 3: { return 5; } case 4: { return 14; } case 5: { return 4; } default: { return -1; } }
         }
+        case 40: { // PION
+            switch slot { case 0: { return 16; } case 1: { return 9; } case 2: { return 15; } case 3: { return 14; } default: { return -1; } }
+        }
+        case 41: { // CORD
+            switch slot { case 0: { return 3; } case 1: { return 15; } case 2: { return 18; } case 3: { return 4; } default: { return -1; } }
+        }
+        case 42: { // SCAV
+            switch slot { case 0: { return 19; } case 1: { return 3; } case 2: { return 1; } case 3: { return 22; } default: { return -1; } }
+        }
+        case 43: { // NITR
+            switch slot { case 0: { return 14; } case 1: { return 9; } case 2: { return 20; } case 3: { return 18; } default: { return -1; } }
+        }
+        case 44: { // MAT
+            switch slot { case 0: { return 13; } case 1: { return 1; } case 2: { return 20; } default: { return -1; } }
+        }
+        case 45: { // THRF
+            switch slot { case 0: { return 20; } case 1: { return 8; } case 2: { return 18; } case 3: { return 6; } default: { return -1; } }
+        }
+        case 46: { // RANG
+            switch slot { case 0: { return 18; } case 1: { return 1; } case 2: { return 14; } case 3: { return 7; } default: { return -1; } }
+        }
+        case 47: { // MINE
+            switch slot { case 0: { return 13; } case 1: { return 9; } case 2: { return 14; } case 3: { return 5; } default: { return -1; } }
+        }
+        case 48: { // SPEC
+            switch slot { case 0: { return 19; } case 1: { return 16; } case 2: { return 5; } case 3: { return 3; } default: { return -1; } }
+        }
+        case 49: { // PAINT
+            switch slot { case 0: { return 16; } case 1: { return 1; } case 2: { return 9; } case 3: { return 14; } case 4: { return 20; } default: { return -1; } }
+        }
         default: { return -1; }
     }
 }
@@ -584,6 +616,37 @@ fn fs_main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
                     let snap = select(0.0, 0.18, fract(capture) > 0.25);
                     col = col + vec3<f32>(1.0, 0.48, 0.08) * (glow + snap);
                     dens = dens + select(0.03, 0.07, face);
+                }
+            }
+            if u.brush_hit.w > 0.5 && u.brush_ui.x > 0.5 {
+                let bc = u.brush_hit.xyz;
+                let voln = max(max(f32(u.width), f32(u.height)), f32(u.depth));
+                let br = max(u.brush_ui.w / max(voln, 1.0), 0.006);
+                let dd = distance(p, bc);
+                if abs(dd - br) < 0.007 {
+                    let si = i32(u.brush_ui.y + 0.5);
+                    var tint = vec3<f32>(0.85, 0.85, 0.80);
+                    if si == 0 { tint = vec3<f32>(0.55, 0.92, 0.82); }
+                    else if si == 1 { tint = vec3<f32>(0.95, 0.72, 0.28); }
+                    else if si == 2 { tint = vec3<f32>(0.78, 0.42, 0.10); }
+                    else if si == 3 { tint = vec3<f32>(0.55, 0.40, 0.85); }
+                    else if si == 4 { tint = vec3<f32>(0.32, 0.70, 0.34); }
+                    else if si == 5 { tint = vec3<f32>(0.90, 0.78, 0.40); }
+                    else if si == 6 { tint = vec3<f32>(0.95, 0.38, 0.42); }
+                    else { tint = vec3<f32>(0.78, 0.84, 0.88); }
+                    if u.brush_ui.x > 1.5 {
+                        let ci = i32(u.brush_ui.z + 0.5);
+                        if ci == 0 { tint = vec3<f32>(0.78, 0.42, 0.10); }
+                        else if ci == 1 { tint = vec3<f32>(0.55, 0.40, 0.85); }
+                        else if ci == 2 { tint = vec3<f32>(0.42, 0.62, 0.88); }
+                        else if ci == 3 { tint = vec3<f32>(0.45, 0.32, 0.18); }
+                        else if ci == 4 { tint = vec3<f32>(0.32, 0.70, 0.34); }
+                        else if ci == 5 { tint = vec3<f32>(0.62, 0.38, 0.16); }
+                        else if ci == 6 { tint = vec3<f32>(0.55, 0.52, 0.22); }
+                        else { tint = vec3<f32>(0.72, 0.22, 0.18); }
+                    }
+                    col = col + tint * 0.85;
+                    dens = dens + 0.045;
                 }
             }
             acc = acc + (1.0 - alpha) * col * dens;
@@ -926,6 +989,76 @@ fn fs_main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
             let pa = row_alpha(cursor, y0, y1, density, fade, sel);
             rgb = paint_label_sz(uv, vec2<f32>(0.032, y0 + 0.003), 32 + pi, pa, 0.0096, 0.016, rgb);
         }
+    }
+
+    // Species preset strip + SPEC / PAINT chips (top center).
+    {
+        let sx0 = 0.268;
+        let sy0 = 0.010;
+        let sy1 = 0.078;
+        let cell = 0.042;
+        let mx0 = sx0 + cell * 8.0 + 0.010;
+        let mw = 0.046;
+        let tool = i32(u.brush_ui.x + 0.5);
+        let sel_sp = i32(u.brush_ui.y + 0.5);
+        let cursor = u.hud_ui.xy;
+        let spec_on = tool == 1;
+        let paint_on = tool == 2;
+        let scol = array<vec3<f32>, 8>(
+            vec3<f32>(0.55, 0.92, 0.82),
+            vec3<f32>(0.95, 0.72, 0.28),
+            vec3<f32>(0.78, 0.42, 0.10),
+            vec3<f32>(0.55, 0.40, 0.85),
+            vec3<f32>(0.32, 0.70, 0.34),
+            vec3<f32>(0.90, 0.78, 0.40),
+            vec3<f32>(0.95, 0.38, 0.42),
+            vec3<f32>(0.78, 0.84, 0.88)
+        );
+        for (var i = 0; i < 8; i++) {
+            let x0 = sx0 + cell * f32(i);
+            let x1 = x0 + cell;
+            let hover = cursor.x >= x0 && cursor.x < x1 && cursor.y >= sy0 && cursor.y <= sy1;
+            let sel = i == sel_sp && spec_on;
+            var body = vec3<f32>(0.040, 0.042, 0.046);
+            if sel {
+                body = mix(vec3<f32>(0.06, 0.06, 0.07), scol[i], 0.22);
+            } else if hover {
+                body = vec3<f32>(0.07, 0.072, 0.078);
+            }
+            if uv.x >= x0 && uv.x < x1 && uv.y >= sy0 && uv.y <= sy1 {
+                rgb = mix(rgb, body, 0.88);
+            }
+            let sh = fill_rect(uv, vec2<f32>(x0, sy0) + px() * 2.0, vec2<f32>(x1, sy1) + px() * 2.0);
+            rgb = mix(rgb, vec3<f32>(0.0, 0.0, 0.0), sh * 0.28);
+            rgb = mix(rgb, vec3<f32>(0.90, 0.91, 0.88), thin_frame(uv, vec2<f32>(x0, sy0), vec2<f32>(x1, sy1)) * select(0.45, 1.0, sel));
+            let glyph = swatch_sz(uv, vec2<f32>(x0 + 0.011, sy0 + 0.008), select(0.55, 1.0, sel), scol[i], vec2<f32>(0.020, 0.028));
+            if glyph.x + glyph.y + glyph.z > 0.0 {
+                rgb = glyph;
+            }
+            rgb = paint_label_sz(uv, vec2<f32>(x0 + 0.003, sy0 + 0.042), 40 + i, 0.92, 0.0084, 0.014, rgb);
+        }
+        let spec_r0 = vec2<f32>(mx0, sy0);
+        let spec_r1 = vec2<f32>(mx0 + mw, sy1);
+        let paint_r0 = vec2<f32>(mx0 + mw + 0.004, sy0);
+        let paint_r1 = vec2<f32>(mx0 + mw * 2.0 + 0.004, sy1);
+        let spec_h = cursor.x >= spec_r0.x && cursor.x <= spec_r1.x && cursor.y >= sy0 && cursor.y <= sy1;
+        let paint_h = cursor.x >= paint_r0.x && cursor.x <= paint_r1.x && cursor.y >= sy0 && cursor.y <= sy1;
+        if uv.x >= spec_r0.x && uv.x <= spec_r1.x && uv.y >= sy0 && uv.y <= sy1 {
+            var body = vec3<f32>(0.040, 0.042, 0.046);
+            if spec_on { body = vec3<f32>(0.16, 0.22, 0.20); }
+            else if spec_h { body = vec3<f32>(0.07, 0.072, 0.078); }
+            rgb = mix(rgb, body, 0.88);
+        }
+        if uv.x >= paint_r0.x && uv.x <= paint_r1.x && uv.y >= sy0 && uv.y <= sy1 {
+            var body = vec3<f32>(0.040, 0.042, 0.046);
+            if paint_on { body = vec3<f32>(0.22, 0.14, 0.08); }
+            else if paint_h { body = vec3<f32>(0.07, 0.072, 0.078); }
+            rgb = mix(rgb, body, 0.88);
+        }
+        rgb = mix(rgb, vec3<f32>(0.90, 0.91, 0.88), thin_frame(uv, spec_r0, spec_r1) * select(0.45, 1.0, spec_on));
+        rgb = mix(rgb, vec3<f32>(0.90, 0.91, 0.88), thin_frame(uv, paint_r0, paint_r1) * select(0.45, 1.0, paint_on));
+        rgb = paint_label_sz(uv, vec2<f32>(mx0 + 0.003, sy0 + 0.028), 48, select(0.55, 1.0, spec_on), 0.0080, 0.016, rgb);
+        rgb = paint_label_sz(uv, vec2<f32>(mx0 + mw + 0.005, sy0 + 0.028), 49, select(0.55, 1.0, paint_on), 0.0072, 0.016, rgb);
     }
 
     let help_fade = clamp(u.overlay_ui.x, 0.0, 1.0);

--- a/pycelium-win/src/shaders/sim.wgsl
+++ b/pycelium-win/src/shaders/sim.wgsl
@@ -42,6 +42,14 @@ struct Uniforms {
     pick_dy: f32,
     pick_dz: f32,
     pad2: f32,
+    brush_x: f32,
+    brush_y: f32,
+    brush_z: f32,
+    brush_radius: f32,
+    brush_strength: f32,
+    brush_channel: f32,
+    brush_mode: f32,
+    brush_lineage: f32,
 }
 
 @group(0) @binding(0) var<uniform> u: Uniforms;
@@ -361,4 +369,163 @@ fn pick(@builtin(global_invocation_id) gid: vec3<u32>) {
     if atomicLoad(&tel[10]) == key {
         atomicStore(&tel[11], id);
     }
+}
+
+// Brush stamps. Mode 1 = inoculate, 2 = erase tips, 3 = paint add, 4 = paint subtract.
+// Paint dispatches a small AABB: gid (0,0,0) is (round(center) - r - 1).
+@compute @workgroup_size(8, 8, 4)
+fn paint(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let mode = u32(u.brush_mode + 0.5);
+    if mode != 3u && mode != 4u {
+        return;
+    }
+    let r = i32(ceil(u.brush_radius)) + 1;
+    let cx = i32(round(u.brush_x));
+    let cy = i32(round(u.brush_y));
+    let cz = i32(round(u.brush_z));
+    let x = cx - r + i32(gid.x);
+    let y = cy - r + i32(gid.y);
+    let z = cz - r + i32(gid.z);
+    if x < 0 || y < 0 || z < 0 {
+        return;
+    }
+    if x >= i32(u.width) || y >= i32(u.height) || z >= i32(u.depth) {
+        return;
+    }
+    let p = vec3<f32>(f32(x) + 0.5, f32(y) + 0.5, f32(z) + 0.5);
+    let center = vec3<f32>(u.brush_x, u.brush_y, u.brush_z);
+    let rad = max(u.brush_radius, 0.75);
+    let d = distance(p, center);
+    if d > rad {
+        return;
+    }
+    let fall = pow(1.0 - d / rad, 1.4);
+    let str = clamp(u.brush_strength, 0.05, 1.5) * fall;
+    let sub = mode == 4u;
+    let ch = u32(u.brush_channel + 0.5) % 8u;
+    let i = idx3(x, y, z);
+
+    if ch == 0u {
+        if sub { soluble_c[i] = max(soluble_c[i] - 0.16 * str, 0.0); }
+        else { soluble_c[i] = soluble_c[i] + 0.14 * str; }
+        return;
+    }
+    if ch == 1u {
+        if sub { soluble_n[i] = max(soluble_n[i] - 0.12 * str, 0.0); }
+        else { soluble_n[i] = soluble_n[i] + 0.10 * str; }
+        return;
+    }
+    if ch == 2u {
+        if sub { moisture[i] = max(moisture[i] - 0.22 * str, 0.02); }
+        else { moisture[i] = min(moisture[i] + 0.20 * str, 0.98); }
+        return;
+    }
+    if ch == 3u {
+        if sub { organic[i] = max(organic[i] - 0.45 * str, 0.0); }
+        else { organic[i] = organic[i] + 0.40 * str; }
+        return;
+    }
+    if ch == 4u {
+        if sub { enzyme[i] = max(enzyme[i] - 0.10 * str, 0.0); }
+        else { enzyme[i] = enzyme[i] + 0.085 * str; }
+        return;
+    }
+    if ch == 5u {
+        if sub {
+            organic[i] = max(organic[i] - 0.80 * str, 0.0);
+            soluble_c[i] = max(soluble_c[i] - 0.08 * str, 0.0);
+        } else {
+            organic[i] = organic[i] + 0.85 * str;
+            soluble_c[i] = soluble_c[i] + 0.07 * str;
+        }
+        return;
+    }
+    if ch == 6u {
+        if sub {
+            organic[i] = max(organic[i] - 0.40 * str, 0.0);
+            soluble_n[i] = max(soluble_n[i] - 0.14 * str, 0.0);
+            soluble_c[i] = max(soluble_c[i] - 0.04 * str, 0.0);
+        } else {
+            organic[i] = organic[i] + 0.38 * str;
+            soluble_n[i] = soluble_n[i] + 0.14 * str;
+            soluble_c[i] = soluble_c[i] + 0.03 * str;
+        }
+        return;
+    }
+    // VOID: always a cutout of existing fields.
+    biomass[i] = max(biomass[i] * (1.0 - 0.88 * str), 0.0);
+    organic[i] = max(organic[i] * (1.0 - 0.80 * str), 0.0);
+    soluble_c[i] = max(soluble_c[i] * (1.0 - 0.80 * str), 0.0);
+    soluble_n[i] = max(soluble_n[i] * (1.0 - 0.80 * str), 0.0);
+    enzyme[i] = max(enzyme[i] * (1.0 - 0.88 * str), 0.0);
+    internal_c[i] = max(internal_c[i] * (1.0 - 0.75 * str), 0.0);
+}
+
+@compute @workgroup_size(64)
+fn inoculate(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let id = gid.x;
+    if id >= u.tip_count {
+        return;
+    }
+    let mode = u32(u.brush_mode + 0.5);
+    let center = vec3<f32>(u.brush_x, u.brush_y, u.brush_z);
+    let rad = max(u.brush_radius, 1.0);
+
+    if mode == 2u {
+        var t = tips[id];
+        if t.state <= 0.0 {
+            return;
+        }
+        if distance(t.pos, center) > rad {
+            return;
+        }
+        let want = u32(u.brush_lineage + 0.5);
+        if want != 0u && t.lineage != want {
+            return;
+        }
+        t.state = 0.0;
+        t.reserve = 0.0;
+        tips[id] = t;
+        return;
+    }
+
+    if mode != 1u {
+        return;
+    }
+    // Parent half only — the upper half is the grow() branch pool.
+    if id >= (u.tip_count / 2u) {
+        return;
+    }
+    if tips[id].state > 0.0 {
+        return;
+    }
+    let cap = max(1u, min(6u, u32(rad / 3.0)));
+    let claimed = atomicAdd(&tel[12], 1u);
+    if claimed >= cap {
+        return;
+    }
+    let h = pcg(id * 747796405u + u.seed + claimed * 17u);
+    let a = f32(h & 1023u) * 0.006135923;
+    let b = f32((h >> 10u) & 1023u) * 0.006135923;
+    let spread = rad * 0.55 * f32((h >> 20u) & 255u) / 255.0;
+    let off = vec3<f32>(sin(a) * cos(b), cos(a) * cos(b), sin(b) * 0.65) * spread;
+    var t = tips[id];
+    var pos = center + off;
+    pos.x = pos.x - f32(u.width) * floor(pos.x / f32(u.width));
+    pos.y = pos.y - f32(u.height) * floor(pos.y / f32(u.height));
+    if pos.x < 0.0 { pos.x = pos.x + f32(u.width); }
+    if pos.y < 0.0 { pos.y = pos.y + f32(u.height); }
+    pos.z = clamp(pos.z, 1.0, f32(u.depth) - 2.0);
+    t.pos = pos;
+    t.dir = safe_norm(off + vec3<f32>(0.12, 0.04, 0.06));
+    if length(t.dir) < 0.1 {
+        t.dir = vec3<f32>(1.0, 0.0, 0.0);
+    }
+    t.age = 0.0;
+    t.reserve = 1.1;
+    t.state = 1.0;
+    t.lineage = max(1u, u32(u.brush_lineage + 0.5));
+    t.parent = 0u;
+    t.flags = 2u;
+    tips[id] = t;
 }

--- a/pycelium-win/src/species.rs
+++ b/pycelium-win/src/species.rs
@@ -1,0 +1,451 @@
+//! Species presets, paint channels, and the top-strip tool chrome.
+//!
+//! Selecting a preset writes the eight global PARAM knobs and arms the
+//! specimen brush with that lineage id. Per-tip genetics / antagonism are
+//! a later hook (`Tip.flags == 2` marks a painted inoculum).
+
+use crate::types::SimUniforms;
+
+pub const SPECIES_COUNT: usize = 8;
+
+/// Top-center strip: left of the slab inset, above the left HUD.
+pub const STRIP_X0: f32 = 0.268;
+pub const STRIP_Y0: f32 = 0.010;
+pub const STRIP_Y1: f32 = 0.078;
+pub const CELL: f32 = 0.042;
+pub const MODE_X0: f32 = STRIP_X0 + CELL * SPECIES_COUNT as f32 + 0.010;
+pub const MODE_W: f32 = 0.046;
+pub const STRIP_X1: f32 = MODE_X0 + MODE_W * 2.0 + 0.004;
+
+pub const RADIUS_MIN: f32 = 1.5;
+pub const RADIUS_MAX: f32 = 24.0;
+pub const RADIUS_DEFAULT: f32 = 5.0;
+pub const STRENGTH_DEFAULT: f32 = 0.55;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ToolMode {
+    View,
+    Specimen,
+    Paint,
+}
+
+impl ToolMode {
+    pub fn cycle(self) -> Self {
+        match self {
+            Self::View => Self::Specimen,
+            Self::Specimen => Self::Paint,
+            Self::Paint => Self::View,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::View => "VIEW",
+            Self::Specimen => "SPECIMEN",
+            Self::Paint => "PAINT",
+        }
+    }
+
+    pub fn as_f32(self) -> f32 {
+        match self {
+            Self::View => 0.0,
+            Self::Specimen => 1.0,
+            Self::Paint => 2.0,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PaintChannel {
+    SolC = 0,
+    SolN = 1,
+    Moisture = 2,
+    Organic = 3,
+    Enzyme = 4,
+    Wood = 5,
+    Litter = 6,
+    Void = 7,
+}
+
+impl PaintChannel {
+    pub fn from_index(i: u8) -> Self {
+        match i % 8 {
+            0 => Self::SolC,
+            1 => Self::SolN,
+            2 => Self::Moisture,
+            3 => Self::Organic,
+            4 => Self::Enzyme,
+            5 => Self::Wood,
+            6 => Self::Litter,
+            _ => Self::Void,
+        }
+    }
+
+    pub fn index(self) -> u8 {
+        self as u8
+    }
+
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::SolC => "SOL C",
+            Self::SolN => "SOL N",
+            Self::Moisture => "H2O",
+            Self::Organic => "ORG",
+            Self::Enzyme => "ENZ",
+            Self::Wood => "WOOD",
+            Self::Litter => "LITTER",
+            Self::Void => "VOID",
+        }
+    }
+
+}
+
+/// One starter species. `params` are absolute knob values for slots 0..7.
+/// `id` / `color` stay on the table so present.wgsl and PAINT.md stay in lockstep.
+#[derive(Clone, Copy, Debug)]
+pub struct SpeciesPreset {
+    #[allow(dead_code)]
+    pub id: u8,
+    pub lineage: u32,
+    pub name: &'static str,
+    pub short: &'static str,
+    #[allow(dead_code)]
+    pub color: [f32; 3],
+    pub params: [f32; 8],
+    pub teach: &'static str,
+}
+
+pub const SPECIES: [SpeciesPreset; SPECIES_COUNT] = [
+    SpeciesPreset {
+        id: 0,
+        lineage: 1,
+        name: "PIONEER",
+        short: "PION",
+        color: [0.55, 0.92, 0.82],
+        params: [2.40, 0.50, 1.40, 0.60, 0.0008, 0.028, 0.28, 1.60],
+        teach: "Pioneer: first arriver. High chemotropism and extension, cheap forks, low persistence. Hunts carbon plumes and fans into empty soil. Lineage 1.",
+    },
+    SpeciesPreset {
+        id: 1,
+        lineage: 2,
+        name: "CORD",
+        short: "CORD",
+        color: [0.95, 0.72, 0.28],
+        params: [1.20, 0.60, 0.35, 2.60, 0.0010, 0.024, 1.40, 1.80],
+        teach: "Cord-former: long committed runs. High persistence and extension, expensive branches, low autotropism so it will recross its own trail. Lineage 2.",
+    },
+    SpeciesPreset {
+        id: 2,
+        lineage: 3,
+        name: "SCAVENGER",
+        short: "SCAV",
+        color: [0.78, 0.42, 0.10],
+        params: [1.80, 0.90, 0.80, 1.10, 0.0014, 0.095, 0.50, 0.90],
+        teach: "Scavenger: litter miner. High enzyme_k and chemotropism so uncleaved polymer unlocks quickly. Medium steps. Lineage 3.",
+    },
+    SpeciesPreset {
+        id: 3,
+        lineage: 4,
+        name: "NITROPHILE",
+        short: "NITR",
+        color: [0.55, 0.40, 0.85],
+        params: [0.40, 2.60, 1.00, 1.20, 0.0011, 0.030, 0.45, 1.10],
+        teach: "Nitrophile: nitrogen hunter. High nitrotropism, low chemotropism. Useful in an N-poor pedon; may ignore rust C plumes. Lineage 4.",
+    },
+    SpeciesPreset {
+        id: 4,
+        lineage: 5,
+        name: "MAT",
+        short: "MAT",
+        color: [0.32, 0.70, 0.34],
+        params: [1.00, 0.70, 0.15, 0.50, 0.0025, 0.040, 0.18, 0.70],
+        teach: "Mat-former: dense local fill. Low autotropism and persistence, cheap branches, short steps. Piles onto itself. Higher maintenance. Lineage 5.",
+    },
+    SpeciesPreset {
+        id: 5,
+        lineage: 6,
+        name: "THRIFTY",
+        short: "THRF",
+        color: [0.90, 0.78, 0.40],
+        params: [0.80, 0.80, 1.20, 2.00, 0.0003, 0.018, 1.20, 0.60],
+        teach: "Thrifty: lean-soil survivor. Very low maintenance, high persistence, expensive forks, short cautious steps. Banks reserve. Lineage 6.",
+    },
+    SpeciesPreset {
+        id: 6,
+        lineage: 7,
+        name: "RANGER",
+        short: "RANG",
+        color: [0.95, 0.38, 0.42],
+        params: [2.20, 0.40, 1.80, 2.20, 0.0010, 0.022, 0.90, 2.00],
+        teach: "Ranger: long hunting arcs. High chemotropism, persistence, autotropism, and extension. Smooth committed runs that still seek C and avoid crowding. Lineage 7.",
+    },
+    SpeciesPreset {
+        id: 7,
+        lineage: 8,
+        name: "MINER",
+        short: "MINE",
+        color: [0.78, 0.84, 0.88],
+        params: [1.30, 1.60, 2.20, 1.00, 0.0120, 0.100, 0.70, 1.00],
+        teach: "Miner: costly aggressive metabolizer. High enzyme_k, autotropism, and maintenance. Placeholder flavor for later antagonism — no chemical warfare yet. Lineage 8.",
+    },
+];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StripHit {
+    Species(u8),
+    SpecimenMode,
+    PaintMode,
+}
+
+#[derive(Clone, Debug)]
+pub struct BrushState {
+    pub mode: ToolMode,
+    pub species: u8,
+    pub channel: PaintChannel,
+    pub radius: f32,
+    pub strength: f32,
+    pub erase: bool,
+    pub stroking: bool,
+    pub last_stamp: Option<[f32; 3]>,
+}
+
+impl Default for BrushState {
+    fn default() -> Self {
+        Self {
+            mode: ToolMode::View,
+            species: 0,
+            channel: PaintChannel::SolC,
+            radius: RADIUS_DEFAULT,
+            strength: STRENGTH_DEFAULT,
+            erase: false,
+            stroking: false,
+            last_stamp: None,
+        }
+    }
+}
+
+impl BrushState {
+    pub fn species_preset(&self) -> &'static SpeciesPreset {
+        &SPECIES[self.species as usize % SPECIES_COUNT]
+    }
+
+    pub fn apply_species(&self, uniforms: &mut SimUniforms) {
+        let p = self.species_preset();
+        for slot in 0..8u32 {
+            uniforms.set_param(slot, p.params[slot as usize]);
+        }
+    }
+
+    pub fn cycle_mode(&mut self) {
+        self.mode = self.mode.cycle();
+        self.stroking = false;
+        self.last_stamp = None;
+    }
+
+    pub fn select_species(&mut self, id: u8, uniforms: &mut SimUniforms) {
+        self.species = id % SPECIES_COUNT as u8;
+        self.mode = ToolMode::Specimen;
+        self.apply_species(uniforms);
+        self.stroking = false;
+        self.last_stamp = None;
+    }
+
+    pub fn select_channel(&mut self, ch: PaintChannel) {
+        self.channel = ch;
+        self.mode = ToolMode::Paint;
+        self.stroking = false;
+        self.last_stamp = None;
+    }
+
+    pub fn nudge_radius(&mut self, steps: f32) {
+        self.radius = (self.radius + steps).clamp(RADIUS_MIN, RADIUS_MAX);
+    }
+
+    pub fn stamp_spacing(&self) -> f32 {
+        (self.radius * 0.40).max(1.2)
+    }
+
+    pub fn should_stamp(&self, pos: [f32; 3]) -> bool {
+        match self.last_stamp {
+            None => true,
+            Some(prev) => {
+                let dx = pos[0] - prev[0];
+                let dy = pos[1] - prev[1];
+                let dz = pos[2] - prev[2];
+                (dx * dx + dy * dy + dz * dz).sqrt() >= self.stamp_spacing()
+            }
+        }
+    }
+
+    pub fn present_vec(&self) -> [f32; 4] {
+        [
+            self.mode.as_f32(),
+            self.species as f32,
+            self.channel.index() as f32,
+            self.radius,
+        ]
+    }
+
+    pub fn toast_title(&self) -> String {
+        match self.mode {
+            ToolMode::View => "VIEW".into(),
+            ToolMode::Specimen => format!("SPEC {}", self.species_preset().short),
+            ToolMode::Paint => format!("PAINT {}", self.channel.name()),
+        }
+    }
+
+    pub fn toast_value(&self) -> String {
+        let erase = if self.erase { "  ERASE" } else { "" };
+        match self.mode {
+            ToolMode::View => "ORBIT  CLICK PICK".into(),
+            ToolMode::Specimen => format!(
+                "LIN {}  R {:.1}{}",
+                self.species_preset().lineage,
+                self.radius,
+                erase
+            ),
+            ToolMode::Paint => format!("R {:.1}  STR {:.2}{}", self.radius, self.strength, erase),
+        }
+    }
+}
+
+pub fn species_cell(i: u8) -> [f32; 4] {
+    let i = i.min(7);
+    let x0 = STRIP_X0 + CELL * i as f32;
+    [x0, STRIP_Y0, x0 + CELL, STRIP_Y1]
+}
+
+pub fn specimen_mode_rect() -> [f32; 4] {
+    [MODE_X0, STRIP_Y0, MODE_X0 + MODE_W, STRIP_Y1]
+}
+
+pub fn paint_mode_rect() -> [f32; 4] {
+    [
+        MODE_X0 + MODE_W + 0.004,
+        STRIP_Y0,
+        MODE_X0 + MODE_W * 2.0 + 0.004,
+        STRIP_Y1,
+    ]
+}
+
+pub fn strip_hit(uv: (f32, f32)) -> Option<StripHit> {
+    if uv.1 < STRIP_Y0 || uv.1 > STRIP_Y1 || uv.0 < STRIP_X0 || uv.0 > STRIP_X1 {
+        return None;
+    }
+    if in_rect(uv, specimen_mode_rect()) {
+        return Some(StripHit::SpecimenMode);
+    }
+    if in_rect(uv, paint_mode_rect()) {
+        return Some(StripHit::PaintMode);
+    }
+    if uv.0 < STRIP_X0 + CELL * SPECIES_COUNT as f32 {
+        let i = ((uv.0 - STRIP_X0) / CELL).floor() as i32;
+        if (0..8).contains(&i) {
+            return Some(StripHit::Species(i as u8));
+        }
+    }
+    None
+}
+
+fn in_rect(uv: (f32, f32), r: [f32; 4]) -> bool {
+    uv.0 >= r[0] && uv.0 <= r[2] && uv.1 >= r[1] && uv.1 <= r[3]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn eight_species_have_unique_lineage_and_in_range_params() {
+        let mut seen = [false; 9];
+        for (i, s) in SPECIES.iter().enumerate() {
+            assert_eq!(s.id as usize, i);
+            assert_eq!(s.lineage, i as u32 + 1);
+            assert!(!seen[s.lineage as usize]);
+            seen[s.lineage as usize] = true;
+            assert!(s.short.len() <= 4);
+            assert!(s.name.len() <= 10);
+            for slot in 0..8u32 {
+                let (lo, hi) = SimUniforms::param_range(slot);
+                let v = s.params[slot as usize];
+                assert!(
+                    v >= lo - 1e-5 && v <= hi + 1e-5,
+                    "{} slot {slot} {v} not in {lo}..{hi}",
+                    s.name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn apply_species_writes_all_eight_knobs() {
+        let mut u = SimUniforms::new(32, 32, 16, 64);
+        let mut brush = BrushState::default();
+        brush.select_species(2, &mut u);
+        assert_eq!(brush.mode, ToolMode::Specimen);
+        assert_eq!(brush.species, 2);
+        for slot in 0..8u32 {
+            assert!((u.param_value(slot) - SPECIES[2].params[slot as usize]).abs() < 1e-5);
+        }
+    }
+
+    #[test]
+    fn strip_hits_species_and_mode_chips() {
+        let pion = species_cell(0);
+        let mid = (0.5 * (pion[0] + pion[2]), 0.5 * (pion[1] + pion[3]));
+        assert_eq!(strip_hit(mid), Some(StripHit::Species(0)));
+        let last = species_cell(7);
+        let m7 = (0.5 * (last[0] + last[2]), 0.5 * (last[1] + last[3]));
+        assert_eq!(strip_hit(m7), Some(StripHit::Species(7)));
+        let spec = specimen_mode_rect();
+        assert_eq!(
+            strip_hit((0.5 * (spec[0] + spec[2]), 0.044)),
+            Some(StripHit::SpecimenMode)
+        );
+        let paint = paint_mode_rect();
+        assert_eq!(
+            strip_hit((0.5 * (paint[0] + paint[2]), 0.044)),
+            Some(StripHit::PaintMode)
+        );
+        assert!(strip_hit((0.04, 0.04)).is_none());
+        assert!(strip_hit((0.50, 0.50)).is_none());
+        assert!(STRIP_X1 < 0.72);
+        assert!(STRIP_Y1 < 0.08);
+    }
+
+    #[test]
+    fn stamp_spacing_skips_tight_samples() {
+        let mut b = BrushState::default();
+        b.radius = 5.0;
+        assert!(b.should_stamp([10.0, 10.0, 10.0]));
+        b.last_stamp = Some([10.0, 10.0, 10.0]);
+        assert!(!b.should_stamp([10.2, 10.0, 10.0]));
+        assert!(b.should_stamp([14.0, 10.0, 10.0]));
+    }
+
+    #[test]
+    fn tool_and_channel_cycle() {
+        assert_eq!(ToolMode::View.cycle(), ToolMode::Specimen);
+        assert_eq!(ToolMode::Specimen.cycle(), ToolMode::Paint);
+        assert_eq!(ToolMode::Paint.cycle(), ToolMode::View);
+        assert_eq!(PaintChannel::from_index(7), PaintChannel::Void);
+        assert_eq!(PaintChannel::Wood.index(), 5);
+        let mut b = BrushState::default();
+        b.nudge_radius(100.0);
+        assert!((b.radius - RADIUS_MAX).abs() < 1e-5);
+        b.nudge_radius(-100.0);
+        assert!((b.radius - RADIUS_MIN).abs() < 1e-5);
+    }
+
+    #[test]
+    fn colors_are_distinct_enough() {
+        for i in 0..SPECIES_COUNT {
+            for j in (i + 1)..SPECIES_COUNT {
+                let a = SPECIES[i].color;
+                let b = SPECIES[j].color;
+                let d = (a[0] - b[0]).abs() + (a[1] - b[1]).abs() + (a[2] - b[2]).abs();
+                assert!(d > 0.18, "{} vs {} too close ({d})", SPECIES[i].name, SPECIES[j].name);
+            }
+        }
+    }
+}

--- a/pycelium-win/src/teach.rs
+++ b/pycelium-win/src/teach.rs
@@ -6,6 +6,9 @@
 //! control has no box (none today on the left HUD), teach cannot fire.
 
 use crate::cutter::{SLIDER_X0, SLIDER_X1, SLIDER_Y0, SLIDER_Y1};
+use crate::species::{
+    paint_mode_rect, species_cell, specimen_mode_rect, strip_hit, StripHit, SPECIES,
+};
 use crate::export_settings::{
     ASPECT_Y0, ASPECT_Y1, CHIP_Y0, CHIP_Y1, FIT_Y0, FIT_Y1, FORMAT_Y0, FORMAT_Y1, HT_Y0, HT_Y1,
     PANEL_X0, PANEL_X1, PANEL_Y1, PRESET_ROW, PRESET_ROWS, PRESET_Y0, SQUARE_PRESETS,
@@ -13,7 +16,7 @@ use crate::export_settings::{
 use crate::hud_font;
 
 pub const HELP_COLS: usize = 26;
-pub const HELP_ROWS: usize = 22;
+pub const HELP_ROWS: usize = 25;
 pub const TIP_COLS: usize = 36;
 pub const TIP_ROWS: usize = 8;
 pub const NUDGE_COLS: usize = 28;
@@ -108,6 +111,18 @@ pub enum HoverId {
     ExportAspect,
     ExportFormat,
     ExportHeightmap,
+    SpeciesPioneer,
+    SpeciesCord,
+    SpeciesScavenger,
+    SpeciesNitro,
+    SpeciesMat,
+    SpeciesThrifty,
+    SpeciesRanger,
+    SpeciesMiner,
+    ToolSpecimen,
+    ToolPaint,
+    BrushRadius,
+    Erase,
 }
 
 #[derive(Clone, Debug)]
@@ -171,6 +186,7 @@ pub enum NudgeKind {
     Thick,
     Zoom,
     Pan,
+    Brush,
 }
 
 impl NudgeKind {
@@ -181,6 +197,7 @@ impl NudgeKind {
             Self::Thick => "; ' THICK  SHIFT COARSE",
             Self::Zoom => ", . ZOOM  SHIFT COARSE",
             Self::Pan => "ARROWS PAN  SHIFT COARSE",
+            Self::Brush => "T TOOL  1-8 SLOT  9/0 R  ALT ERASE",
         }
     }
 
@@ -190,6 +207,7 @@ impl NudgeKind {
             Self::SliceZ => 0.570,
             Self::Thick => 0.612,
             Self::Zoom | Self::Pan => 0.656,
+            Self::Brush => 0.118,
         }
     }
 }
@@ -278,13 +296,16 @@ const SCHEME_ROWS: &[SchemeRow] = &[
     SchemeRow { keys: "H", action: "SCHEME", id: HoverId::Help },
     SchemeRow { keys: "DRAG", action: "ORBIT", id: HoverId::Orbit },
     SchemeRow { keys: "WHEEL", action: "DOLLY", id: HoverId::Dolly },
-    SchemeRow { keys: "CLICK", action: "PICK TIP", id: HoverId::Pick },
+    SchemeRow { keys: "CLICK", action: "PICK / DRAW", id: HoverId::Pick },
+    SchemeRow { keys: "T", action: "SPEC / PAINT", id: HoverId::ToolSpecimen },
+    SchemeRow { keys: "9 0", action: "BRUSH R", id: HoverId::BrushRadius },
+    SchemeRow { keys: "ALT", action: "ERASE", id: HoverId::Erase },
     SchemeRow { keys: "[ ]", action: "SLICE Z", id: HoverId::SliceKeys },
     SchemeRow { keys: "; '", action: "THICK", id: HoverId::ThickKeys },
     SchemeRow { keys: ", .", action: "XY ZOOM", id: HoverId::ZoomKeys },
     SchemeRow { keys: "ARROWS", action: "PAN SLAB", id: HoverId::PanKeys },
     SchemeRow { keys: "SHIFT", action: "COARSE", id: HoverId::Shift },
-    SchemeRow { keys: "1-8", action: "PARAM", id: HoverId::ParamKeys },
+    SchemeRow { keys: "1-8", action: "SLOT", id: HoverId::ParamKeys },
     SchemeRow { keys: "- =", action: "NUDGE", id: HoverId::Nudge },
     SchemeRow { keys: "TAB", action: "DENSITY", id: HoverId::Tab },
     SchemeRow { keys: "E", action: "CAPTURE", id: HoverId::Capture },
@@ -298,6 +319,19 @@ const SCHEME_ROWS: &[SchemeRow] = &[
     SchemeRow { keys: "ENTER", action: "WRITE", id: HoverId::Write },
     SchemeRow { keys: "ESC", action: "LEAVE", id: HoverId::Leave },
 ];
+
+fn species_hover_id(id: u8) -> HoverId {
+    match id % 8 {
+        0 => HoverId::SpeciesPioneer,
+        1 => HoverId::SpeciesCord,
+        2 => HoverId::SpeciesScavenger,
+        3 => HoverId::SpeciesNitro,
+        4 => HoverId::SpeciesMat,
+        5 => HoverId::SpeciesThrifty,
+        6 => HoverId::SpeciesRanger,
+        _ => HoverId::SpeciesMiner,
+    }
+}
 
 pub fn in_rect(uv: (f32, f32), r: [f32; 4]) -> bool {
     uv.0 >= r[0] && uv.0 <= r[2] && uv.1 >= r[1] && uv.1 <= r[3]
@@ -382,6 +416,23 @@ pub fn hit_test(
                 [0.5 * (SLIDER_X0 + SLIDER_X1), 0.5 * (SLIDER_Y0 + SLIDER_Y1)],
             );
         }
+    }
+
+    if let Some(hit) = strip_hit(cursor) {
+        return match hit {
+            StripHit::Species(i) => {
+                let r = species_cell(i);
+                (species_hover_id(i), [r[0], 0.5 * (r[1] + r[3])])
+            }
+            StripHit::SpecimenMode => {
+                let r = specimen_mode_rect();
+                (HoverId::ToolSpecimen, [r[0], 0.5 * (r[1] + r[3])])
+            }
+            StripHit::PaintMode => {
+                let r = paint_mode_rect();
+                (HoverId::ToolPaint, [r[0], 0.5 * (r[1] + r[3])])
+            }
+        };
     }
 
     if cursor.0 >= HUD_X0 && cursor.0 <= HUD_X1 {
@@ -617,7 +668,7 @@ fn tip_text(id: HoverId) -> &'static str {
             "Internal carbon the picked tip is carrying (shown times 100). Extension and branching spend this. A starved tip stops growing even if soil food is nearby, until uptake refills it."
         }
         HoverId::Param | HoverId::ParamKeys => {
-            "Eight left-HUD sliders: chemotropism, nitrotropism, autotropism, persistence, maintenance, enzyme_k, branch cost, extension. Keys 1-8 select. Minus and equals nudge the focused slot. Drag any track to set it and select it."
+            "Eight PARAM sliders. In VIEW, 1-8 select a knob; minus and equals nudge it. Drag any track to set it. In SPECIMEN, 1-8 pick a species; in PAINT they pick a field channel."
         }
         HoverId::ParamChemo => {
             "Chemotropism steers each tip toward soluble carbon, the rust SOL C field. High: tips hunt food plumes and bend hard toward litter. Low: they ignore C gradients and wander or follow persistence, nitrogen, or autotropism instead. Key 1. Drag the track or use minus and equals."
@@ -647,13 +698,13 @@ fn tip_text(id: HoverId) -> &'static str {
             "H toggles this corner control-scheme panel, always, including in capture. It never writes a heightmap. Hover a row here, or a left HUD meter, for a teach callout on a white string."
         }
         HoverId::Orbit => {
-            "Left-drag orbits the camera around the pedon. This is the view, not the fungus. Grabbing a capture slider handle or the export card does not start an orbit."
+            "Left-drag orbits in VIEW. In SPECIMEN or PAINT, right-drag orbits so the left button can stamp. Grabbing a HUD slider, the species strip, or the export card does not start an orbit."
         }
         HoverId::Dolly => {
-            "Mouse wheel moves the eye in and out (dolly). Shift+wheel in capture instead thickens the cutter. Wheel over the export card cycles the square size preset."
+            "Mouse wheel dollies in VIEW. In SPECIMEN or PAINT it changes brush radius instead. Shift+wheel in capture thickens the cutter. Wheel over the export card cycles the square size preset."
         }
         HoverId::Pick => {
-            "Click in the volume to select the nearest live tip. The TIP / LINEAGE / AGE / RESERVE block then tracks that slot. Disabled while capturing so the cutter can keep the mouse."
+            "In VIEW, click the volume to pick the nearest live tip. In SPECIMEN or PAINT, left-drag stamps along the ray into the cube (same midpoint as the capture cutter). Right-drag still orbits. Capture disables pick and stamps."
         }
         HoverId::SliceKeys => {
             "Open bracket and close bracket step the view-slab depth. Shift makes the step coarse (8 voxels). This drives the orange plane and the inset, not the capture cutter."
@@ -721,6 +772,26 @@ fn tip_text(id: HoverId) -> &'static str {
         HoverId::ExportHeightmap => {
             "Click to arm the optional heightmap PNG (same as M). Y still picks the height axis. H never writes a heightmap."
         }
+        HoverId::SpeciesPioneer => SPECIES[0].teach,
+        HoverId::SpeciesCord => SPECIES[1].teach,
+        HoverId::SpeciesScavenger => SPECIES[2].teach,
+        HoverId::SpeciesNitro => SPECIES[3].teach,
+        HoverId::SpeciesMat => SPECIES[4].teach,
+        HoverId::SpeciesThrifty => SPECIES[5].teach,
+        HoverId::SpeciesRanger => SPECIES[6].teach,
+        HoverId::SpeciesMiner => SPECIES[7].teach,
+        HoverId::ToolSpecimen => {
+            "Specimen tool: click-drag inoculates germ tubes of the selected species into the box. Selecting a square also writes that species' eight PARAM biases (global knobs, not per-tip genes yet). Flags=2 marks a painted inoculum. T cycles VIEW / SPECIMEN / PAINT."
+        }
+        HoverId::ToolPaint => {
+            "Paint tool: click-drag writes real GPU field buffers. 1-8 pick the channel: SOL C, SOL N, H2O, ORG, ENZ, WOOD, LITTER, VOID. VOID is a cutout of existing fields, not a new poison buffer. T cycles tools."
+        }
+        HoverId::BrushRadius => {
+            "Brush radius in voxels. Keys 9 and 0 shrink or grow it. Mouse wheel does the same while SPECIMEN or PAINT is armed (in VIEW the wheel still dollies). Shift coarsens the step."
+        }
+        HoverId::Erase => {
+            "Hold Alt to subtract. In SPECIMEN that kills tips of the selected lineage inside the brush. In PAINT it removes the armed channel. VOID always cuts out. Right-drag orbits while a tool is armed."
+        }
     }
 }
 
@@ -753,6 +824,12 @@ mod tests {
         assert_eq!(id, HoverId::ParamExtend);
         let (id, _) = hit_test((0.40, 0.110), false, false, false);
         assert_eq!(id, HoverId::None);
+        let pion = crate::species::species_cell(0);
+        let (id, _) = hit_test((0.5 * (pion[0] + pion[2]), 0.044), false, false, false);
+        assert_eq!(id, HoverId::SpeciesPioneer);
+        let spec = crate::species::specimen_mode_rect();
+        let (id, _) = hit_test((0.5 * (spec[0] + spec[2]), 0.044), false, false, false);
+        assert_eq!(id, HoverId::ToolSpecimen);
     }
 
     #[test]
@@ -785,6 +862,14 @@ mod tests {
         assert!(wrap_text(tip_text(HoverId::Param), TIP_COLS).len() <= TIP_ROWS);
         assert!(wrap_text(tip_text(HoverId::ExportFormat), TIP_COLS).len() <= TIP_ROWS);
         assert!(wrap_text(tip_text(HoverId::ExportHeightmap), TIP_COLS).len() <= TIP_ROWS);
+        assert!(wrap_text(tip_text(HoverId::ToolSpecimen), TIP_COLS).len() <= TIP_ROWS);
+        assert!(wrap_text(tip_text(HoverId::ToolPaint), TIP_COLS).len() <= TIP_ROWS);
+        assert!(wrap_text(tip_text(HoverId::BrushRadius), TIP_COLS).len() <= TIP_ROWS);
+        assert!(wrap_text(tip_text(HoverId::Erase), TIP_COLS).len() <= TIP_ROWS);
+        for s in crate::species::SPECIES {
+            let n = wrap_text(s.teach, TIP_COLS).len();
+            assert!(n <= TIP_ROWS, "{} teach wraps to {n} lines", s.name);
+        }
         for slot in 0..8u32 {
             let id = param_hover(slot);
             let n = wrap_text(tip_text(id), TIP_COLS).len();

--- a/pycelium-win/src/types.rs
+++ b/pycelium-win/src/types.rs
@@ -72,6 +72,14 @@ pub struct SimUniforms {
     pub pick_dy: f32,
     pub pick_dz: f32,
     pub pad2: f32,
+    pub brush_x: f32,
+    pub brush_y: f32,
+    pub brush_z: f32,
+    pub brush_radius: f32,
+    pub brush_strength: f32,
+    pub brush_channel: f32,
+    pub brush_mode: f32,
+    pub brush_lineage: f32,
 }
 
 impl SimUniforms {
@@ -109,6 +117,14 @@ impl SimUniforms {
             pick_dy: 0.0,
             pick_dz: 1.0,
             pad2: 0.0,
+            brush_x: 0.0,
+            brush_y: 0.0,
+            brush_z: 0.0,
+            brush_radius: 5.0,
+            brush_strength: 0.55,
+            brush_channel: 0.0,
+            brush_mode: 0.0,
+            brush_lineage: 1.0,
         }
     }
 
@@ -246,6 +262,11 @@ pub struct PresentUniforms {
     pub nudge_rect: [f32; 4],
     /// Normalized 0..1 fills for the eight left-HUD param sliders.
     pub param_fills: [f32; 8],
+    /// Tool strip: x = mode (0 view / 1 specimen / 2 paint), y = species 0..7,
+    /// z = paint channel 0..7, w = brush radius in voxels.
+    pub brush_ui: [f32; 4],
+    /// Cursor volume hit for the brush ghost: xyz unit-cube, w = 1 when armed.
+    pub brush_hit: [f32; 4],
 }
 
 /// Orthogonal section through the pedon. Depth is the plane; thickness is
@@ -339,7 +360,8 @@ mod tests {
     fn present_uniforms_stay_16_byte_aligned() {
         assert_eq!(std::mem::size_of::<PresentUniforms>() % 16, 0);
         assert!(std::mem::size_of::<PresentUniforms>() >= 176);
-        assert_eq!(std::mem::size_of::<PresentUniforms>(), 16 * 19);
+        assert_eq!(std::mem::size_of::<PresentUniforms>(), 16 * 21);
+        assert_eq!(std::mem::size_of::<SimUniforms>() % 16, 0);
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Eight starter-species squares, click-drag inoculate, and real GPU field stamps for the mesocosm. Ready to merge.

## What landed

**Species strip** (top center, between left HUD and slab inset)
- Eight small squares: colored glyph + short name (PION / CORD / SCAV / NITR / MAT / THRF / RANG / MINE)
- Click a square to arm the specimen brush and write that species’ eight PARAM knobs
- SPEC / PAINT chips on the right of the row
- Hover teach + live toast (same family as param nudge)

**Specimen draw**
- Left-drag shoots the existing ray into the cube (cutter midpoint) and inoculates germ tubes of the selected lineage
- New tips claim dormant **parent-half** slots so `grow()` keeps its branch pool
- `Tip.lineage` = 1…8, `Tip.flags = 2` (startup germs stay 0; branches stay 1)
- Alt erases tips of that lineage inside the brush

**Field paint**
- Real compute writes on a radius AABB (not a full-volume pass): SOL C, SOL N, H2O, ORG, ENZ, WOOD, LITTER, VOID
- VOID is a cutout of existing buffers (biomass / organic / soluble / enzyme / tips). No new poison field.
- Moisture and enzyme already gate `kinetics` / `diffuse`

## Controls

| Bind | Action |
|------|--------|
| `T` | VIEW → SPECIMEN → PAINT |
| Click square | Arm species + specimen |
| `1–8` | VIEW: param. SPECIMEN: species. PAINT: channel |
| `9` `0` / wheel when armed | Brush radius |
| Alt | Subtract / erase |
| Right-drag | Orbit while a tool is armed |

Tab density, H scheme, E/S export, and the eight sliders are unchanged in VIEW.

## Docs

- [docs/PAINT.md](docs/PAINT.md) — species table, channels, GPU notes, extension hook (per-lineage genes / antagonism later)
- [docs/HUD_LEGEND.md](docs/HUD_LEGEND.md) and README controls updated

## Tests

`cargo test -p pycelium-win --locked` — 69 passed (includes naga validate of `sim.wgsl` + `present.wgsl`).

No GPU window in this environment, so the strip and stroke were not visually exercised. `--bench` is unchanged and still headless.

## Deliberate scope

Params stay **global** (selecting a species writes the eight knobs for everyone). Miner is flavor + a costly enzyme/maintenance mix, not chemical warfare. Those are the documented hooks for a later genetics pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2b4fbe3-036c-4a56-825d-7e21d5b295fa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2b4fbe3-036c-4a56-825d-7e21d5b295fa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

