### PR TITLE
Windows GPU: build.bat / run.bat with pause, build.log, and exe mtime

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# cmd.exe double-click needs CRLF or the window can vanish before pause.
+*.bat text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ docs/_build/
 
 # PyBuilder / Rust
 target/
+/build.log
 *.pdb
 
 # Mesocosm slice captures

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ cargo run -p pycelium-win --release -- --preset demo
 # --bench N is headless and does not open the HUD
 ```
 
+Windows: double-click `build.bat` (release binary at `target\release\pycelium-win.exe`). Double-click `run.bat` to build then open the GPU window (`run.bat demo` / `performant` / `beast`). If the console closes, open `build.log` in the repo root.
+
 ### Experiment log
 
 Logged trials (presets, `--drift` / `--bench`, HUD bake metrics) live in

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,104 @@
+@echo off
+setlocal EnableExtensions
+cd /d "%~dp0"
+
+REM Always pause on double-click. /nopause is only for run.bat
+REM so it can launch the GPU window without a mid-script keypress.
+set "NOPAUSE=0"
+if /I "%~1"=="/nopause" set "NOPAUSE=1"
+
+set "LOG=%~dp0build.log"
+set "BIN=%~dp0target\release\pycelium-win.exe"
+set "RC=0"
+set "STARTED=%DATE% %TIME%"
+
+REM Double-click PATH is often empty of rustup. Prefer the user cargo bin.
+if exist "%USERPROFILE%\.cargo\bin" (
+  set "PATH=%USERPROFILE%\.cargo\bin;%PATH%"
+)
+
+echo.
+echo Started: %STARTED%
+echo Building Pycelium GPU mesocosm - release, package pycelium-win
+echo   cargo build --release -p pycelium-win
+echo   log: %LOG%
+echo.
+
+> "%LOG%" echo Pycelium GPU mesocosm release build
+>> "%LOG%" echo Started: %STARTED%
+>> "%LOG%" echo cargo build --release -p pycelium-win
+>> "%LOG%" echo.
+
+where cargo >nul 2>&1
+if errorlevel 1 (
+  echo cargo was not found.
+  echo Install Rust from https://rustup.rs then double-click build.bat again.
+  echo rustup puts cargo in %%USERPROFILE%%\.cargo\bin - this script already adds that folder.
+  echo.
+  echo cargo was not found.>> "%LOG%"
+  echo Install Rust from https://rustup.rs>> "%LOG%"
+  set "RC=1"
+  goto :finish
+)
+
+call :tee_cargo
+set "RC=%ERRORLEVEL%"
+if not "%RC%"=="0" (
+  echo.
+  echo cargo build --release -p pycelium-win failed.
+  echo Open build.log in the repo root if this window is gone.
+  echo cargo build --release -p pycelium-win failed. code %RC%>> "%LOG%"
+  goto :finish
+)
+
+echo.
+if exist "%BIN%" (
+  echo Binary: %BIN%
+  echo Binary: %BIN%>> "%LOG%"
+  echo.
+  echo pycelium-win.exe last write time and size:
+  echo pycelium-win.exe last write time and size:>> "%LOG%"
+  dir /T:W "%BIN%"
+  dir /T:W "%BIN%" >> "%LOG%"
+) else (
+  echo Build succeeded but %BIN% is missing. Check cargo output above or build.log.
+  echo Build succeeded but binary missing: %BIN%>> "%LOG%"
+  set "RC=1"
+  goto :finish
+)
+
+:finish
+echo.
+echo Finished: %DATE% %TIME%
+echo Finished: %DATE% %TIME%>> "%LOG%"
+if not "%RC%"=="0" (
+  echo Result: FAILED  code %RC%
+  echo Result: FAILED  code %RC%>> "%LOG%"
+) else (
+  echo Result: OK
+  echo Result: OK>> "%LOG%"
+)
+echo.
+echo If this window closed on its own, open build.log in the repo root.
+echo.
+if "%NOPAUSE%"=="1" exit /b %RC%
+echo Press any key to close this window.
+pause
+exit /b %RC%
+
+:tee_cargo
+REM Live cargo on the console, same text appended to build.log.
+REM *>&1 is PowerShell redirect so cmd.exe does not steal 2>&1.
+REM No parenthesized blocks here: %ERRORLEVEL% would expand too early.
+where powershell.exe >nul 2>&1
+if not errorlevel 1 goto :tee_ps
+echo powershell.exe not found; cargo output goes to build.log, then typed back.
+cargo build --release -p pycelium-win >> "%LOG%" 2>&1
+set "TEE_RC=%ERRORLEVEL%"
+echo ---- build.log ----
+type "%LOG%"
+exit /b %TEE_RC%
+
+:tee_ps
+powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "& cargo build --release -p pycelium-win *>&1 | Tee-Object -FilePath 'build.log' -Append; if ($null -ne $global:LASTEXITCODE) { exit [int]$global:LASTEXITCODE }; exit 0"
+exit /b %ERRORLEVEL%

--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,53 @@
+@echo off
+setlocal EnableExtensions
+cd /d "%~dp0"
+
+REM Build first (no success-pause - we go straight to the window).
+REM build.bat still writes build.log and always pauses when double-clicked.
+call "%~dp0build.bat" /nopause
+if errorlevel 1 (
+  echo.
+  echo Build failed. Open build.log in the repo root if this window is gone.
+  echo.
+  pause
+  exit /b 1
+)
+
+set "BIN=%~dp0target\release\pycelium-win.exe"
+if not exist "%BIN%" (
+  echo Expected binary missing: %BIN%
+  echo Open build.log in the repo root if this window is gone.
+  pause
+  exit /b 1
+)
+
+REM Quality presets: demo / performant / beast. Other flags pass through
+REM (e.g. --preset demo --drift, --bench 60).
+set "ARGS=%*"
+if /I "%~1"=="demo" goto :preset
+if /I "%~1"=="performant" goto :preset
+if /I "%~1"=="beast" goto :preset
+goto :launch
+
+:preset
+set "ARGS=--preset %~1"
+if not "%~2"=="" set "ARGS=%ARGS% %~2 %~3 %~4 %~5 %~6 %~7 %~8 %~9"
+
+:launch
+echo.
+echo Launching Pycelium GPU mesocosm
+echo   %BIN% %ARGS%
+echo Close the window to return here.
+echo.
+
+REM Run in this console so we wait on the real process.
+REM Do not `start`+detach, and do not `timeout /t` (feel-lab StartServer.bat:
+REM Git Bash / Firefox timeout.exe spam "Invalid time interval" and can
+REM drop the child early). Extra args pass through (presets / --drift / --bench).
+"%BIN%" %ARGS%
+set "RC=%ERRORLEVEL%"
+
+echo.
+echo pycelium-win exited with code %RC%.
+pause
+exit /b %RC%


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Explorer double-click of a missing Windows builder was closing with no readable success/fail and no way to tell if `target\release\pycelium-win.exe` was fresh. This ports the working fulcrumRust pattern (PR #48 / tip `build.bat` + run companion) for the GPU mesocosm.

## Changes
- **`build.bat` always pauses** on success and failure (single `:finish` path). `/nopause` is only for `run.bat` so the GPU window can launch without a mid-script keypress.
- **Tee cargo** to repo-root `build.log` (overwrite each run) via PowerShell `Tee-Object`, with a redirect+`type` fallback if PowerShell is missing. Command is `cargo build --release -p pycelium-win`.
- After a successful build, print **`dir /T:W` mtime + size** of `target\release\pycelium-win.exe`.
- Print **start/end timestamps** and `Result: OK` / `FAILED`.
- If the window still vanishes: **open `build.log`** (README one-liner + on-screen hint).
- **`.gitattributes`**: `*.bat text eol=crlf` so cmd.exe does not skip `pause` on LF-only files.
- **`run.bat`**: build then launch in the same console (no silent `exit` on build failure; no `start`+detach, no `timeout /t`). Quality presets: `run.bat demo` / `performant` / `beast` (or pass `--preset` / `--drift` / `--bench` through).

Did not wrap with `cmd /k` (prefer honest pause + log first). Did not touch fulcrumRust.

## Verify
- Double-click `build.bat` from Explorer: window stays open; success/fail is readable; `pycelium-win.exe` write time + size printed; `build.log` in repo root.
- Double-click `run.bat` to build then open the GPU window. Shortcut: `run.bat demo`.
- This Linux agent cannot double-click the `.bat`. Engine unit tests are unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e8a4157-f2f3-48b8-81bb-76402757cd37?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e8a4157-f2f3-48b8-81bb-76402757cd37&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

