### PR TITLE
Quiet build.bat tee — no PowerShell NativeCommandError red

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -87,18 +87,16 @@ pause
 exit /b %RC%
 
 :tee_cargo
-REM Live cargo on the console, same text appended to build.log.
-REM *>&1 is PowerShell redirect so cmd.exe does not steal 2>&1.
-REM No parenthesized blocks here: %ERRORLEVEL% would expand too early.
-where powershell.exe >nul 2>&1
-if not errorlevel 1 goto :tee_ps
-echo powershell.exe not found; cargo output goes to build.log, then typed back.
-cargo build --release -p pycelium-win >> "%LOG%" 2>&1
+REM Cargo writes compile progress to stderr. Do not pipe through PowerShell
+REM Tee-Object: it wraps stderr as NativeCommandError / RemoteException and
+REM paints it red even when cargo exits 0 (Result: OK, fresh pycelium-win.exe).
+REM cmd-native tee: merge streams into a temp, type to the console, append
+REM to build.log. No parenthesized blocks: %ERRORLEVEL% would expand too early.
+if not defined TEMP set "TEMP=%~dp0"
+set "TEE_TMP=%TEMP%\pycelium-build-%RANDOM%%RANDOM%.tmp"
+cargo build --release -p pycelium-win > "%TEE_TMP%" 2>&1
 set "TEE_RC=%ERRORLEVEL%"
-echo ---- build.log ----
-type "%LOG%"
+type "%TEE_TMP%"
+type "%TEE_TMP%" >> "%LOG%"
+del /q "%TEE_TMP%" >nul 2>&1
 exit /b %TEE_RC%
-
-:tee_ps
-powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "& cargo build --release -p pycelium-win *>&1 | Tee-Object -FilePath 'build.log' -Append; if ($null -ne $global:LASTEXITCODE) { exit [int]$global:LASTEXITCODE }; exit 0"
-exit /b %ERRORLEVEL%


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bug

`build.bat` teed cargo through PowerShell `Tee-Object`. Cargo writes compile progress to **stderr**. Windows PowerShell wraps that as `NativeCommandError` / `RemoteException` and paints it red even when the build succeeds (`Result: OK`, fresh `pycelium-win.exe`).

This is the same failure fulcrumRust PR #49 fixed. pycelium #13 ported the earlier PowerShell tee; this mirrors the quiet cmd-native replacement.

## Fix

Drop the PowerShell tee. cmd-native capture:

1. `cargo build --release -p pycelium-win > %TEMP%\pycelium-build-*.tmp 2>&1`
2. `type` the temp to the console
3. append the same text to `build.log`
4. delete the temp
5. `exit /b` cargo's saved `ERRORLEVEL`

No PowerShell host, so no false-red ErrorRecords.

## Kept (same as #13)

- Always-pause on double-click
- `/nopause` for `run.bat` so the GPU window can launch without a mid-script keypress
- Start/finish timestamps on console + log
- `dir /T:W` `pycelium-win.exe` mtime/size
- `Result: OK` / `Result: FAILED`
- CRLF on `*.bat` (`.gitattributes`)

`run.bat` is unchanged; it still calls `build.bat /nopause`.

## Verify (Windows)

Double-click `build.bat`. A successful compile should show cargo lines in the default console color — no red `NativeCommandError` / `RemoteException` spam — then `Result: OK`, `pycelium-win.exe` mtime/size, and the pause. `build.log` in the repo root should contain the same cargo text.

`run.bat` should still skip the mid-script pause and launch the GPU window when the build is OK.

This Linux agent cannot double-click the `.bat`. Engine unit tests are unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d39c94bc-9117-449f-ad80-d60416eb040f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d39c94bc-9117-449f-ad80-d60416eb040f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

